### PR TITLE
Rebrand to HABirdDashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AvianVisitors for Home Assistant
+# HABirdDashboard
 
-*A live bird collage from your window - as a Home Assistant dashboard, fed by BirdNET-Go.*
+*A live bird collage for Home Assistant, fed by BirdNET-Go.*
 
-<img alt="avianvisitors collage" src="docs/thumb.png" />
+<img alt="HABirdDashboard collage" src="docs/thumb.png" />
 
 A dashboard for the data the
 [BirdNET-Go Home Assistant app](https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go)
@@ -18,9 +18,11 @@ static page served from Home Assistant's `www` folder (no separate app, no
 server, no database of its own), and the browser reads your BirdNET-Go
 app's REST API directly.
 
-This is a fork of [AvianVisitors](https://github.com/Twarner491/AvianVisitors)
-(which runs on BirdNET-Pi on a dedicated Raspberry Pi), reworked to run
-against the BirdNET-Go app on Home Assistant.
+The artwork and the silhouette-masking collage layout come from
+[AvianVisitors](https://github.com/Twarner491/AvianVisitors) (a BirdNET-Pi
+project for a dedicated Raspberry Pi); everything else here - the data
+layer, the confidence-based poses, the deployment - is built for Home
+Assistant + BirdNET-Go.
 
 ---
 
@@ -113,12 +115,12 @@ them there:
 open its web terminal, and run:
 
 ```bash
-git clone https://github.com/adamoberley/avianvisitorsHA.git /tmp/avianvisitors
-/tmp/avianvisitors/homeassistant/install.sh
-rm -rf /tmp/avianvisitors
+git clone https://github.com/adamoberley/HABirdDashboard.git /tmp/habird
+/tmp/habird/homeassistant/install.sh
+rm -rf /tmp/habird
 ```
 
-That copies everything to `/config/www/avianvisitors` (the artwork is
+That copies everything to `/config/www/habird` (the artwork is
 ~350MB, so the clone and copy take a minute or two).
 
 **Option B - Samba (no terminal):** install the official **Samba share**
@@ -127,7 +129,7 @@ app, then from your computer:
 1. Download this repo as a ZIP (**Code → Download ZIP** on GitHub) and
    extract it.
 2. Open HA's network share (`\\homeassistant\config` on Windows,
-   `smb://homeassistant/config` on Mac) and create `www/avianvisitors/`.
+   `smb://homeassistant/config` on Mac) and create `www/habird/`.
 3. Copy into that folder:
    - all five files from `homeassistant/www/` (`index.html`, `config.js`,
      `apt.js`, `styles.css`, `favicon.png`),
@@ -137,7 +139,7 @@ app, then from your computer:
 Then open it in a browser to check it works:
 
 ```
-http://<your-ha-host>:8123/local/avianvisitors/index.html
+http://<your-ha-host>:8123/local/habird/index.html
 ```
 
 > Blank 404? If `/config/www` didn't exist before this, restart Home
@@ -147,7 +149,7 @@ http://<your-ha-host>:8123/local/avianvisitors/index.html
 ## Step 4 — Add it to Home Assistant
 
 **Sidebar (recommended):** **Settings → Dashboards → + Add dashboard →
-Webpage**, URL `/local/avianvisitors/index.html`, give it a name like
+Webpage**, URL `/local/habird/index.html`, give it a name like
 "Birds" and an icon (`mdi:bird`). It appears in your sidebar, full screen.
 
 **As a card instead:** add a **Webpage** card to any existing dashboard with
@@ -160,7 +162,7 @@ has history, it shows up immediately.
 
 ## Configuration
 
-Edit `/config/www/avianvisitors/config.js`:
+Edit `/config/www/habird/config.js`:
 
 ```js
 window.AV_CONFIG = {

--- a/homeassistant/install.sh
+++ b/homeassistant/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# AvianVisitors for Home Assistant + BirdNET-Go - installer.
+# HABirdDashboard - installer.
 #
 # Copies the static dashboard (homeassistant/www) plus the bundled bird
 # illustrations (avian/assets) into Home Assistant's www folder, where it
-# is served at /local/avianvisitors/index.html.
+# is served at /local/habird/index.html.
 #
 # Run it from a clone of this repo on the machine that can see your HA
 # config directory - e.g. inside the "Terminal & SSH" app
@@ -11,18 +11,18 @@
 # folder mounted via the Samba app.
 #
 # Usage:
-#   ./install.sh [target]        # default target: /config/www/avianvisitors
+#   ./install.sh [target]        # default target: /config/www/habird
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TARGET="${1:-/config/www/avianvisitors}"
+TARGET="${1:-/config/www/habird}"
 
 if [ ! -d "$(dirname "$TARGET")" ]; then
   mkdir -p "$(dirname "$TARGET")"
 fi
 
-echo "Installing AvianVisitors dashboard to: $TARGET"
+echo "Installing HABirdDashboard to: $TARGET"
 mkdir -p "$TARGET/assets"
 
 # Frontend (index.html, apt.js, styles.css, config.js, favicon).
@@ -44,6 +44,6 @@ cp -r "$REPO_ROOT/avian/assets/illustrations" "$TARGET/assets/"
 cp -r "$REPO_ROOT/avian/assets/cutouts" "$TARGET/assets/"
 
 echo
-echo "Done. Open: http://<your-home-assistant>:8123/local/avianvisitors/index.html"
+echo "Done. Open: http://<your-home-assistant>:8123/local/habird/index.html"
 echo "Then add it to HA: Settings -> Dashboards -> Add dashboard -> Webpage,"
-echo "with URL /local/avianvisitors/index.html"
+echo "with URL /local/habird/index.html"

--- a/homeassistant/www/config.js
+++ b/homeassistant/www/config.js
@@ -1,4 +1,4 @@
-// AvianVisitors for Home Assistant + BirdNET-Go - user configuration.
+// HABirdDashboard - user configuration.
 // Loaded before apt.js so the dashboard knows where your BirdNET-Go
 // instance lives and how to choose each bird's pose.
 window.AV_CONFIG = {


### PR DESCRIPTION
Prepares the repo for the GitHub rename to **HABirdDashboard**:

- README title, tagline, and clone URL use the new name; the intro now credits [AvianVisitors](https://github.com/Twarner491/AvianVisitors) specifically for what's kept from it — the artwork and the silhouette-masking collage layout — with everything else (data layer, confidence poses, deployment) framed as this project's own.
- The deployed folder is renamed to match: default install target `/config/www/habird`, dashboard URL `/local/habird/index.html`, consistent across the README walkthrough and `install.sh` (which still accepts a custom target argument). Installer re-tested.
- Installer/config file headers renamed.

After merging, rename the repo in GitHub: **Settings → General → Repository name → `HABirdDashboard`**. GitHub redirects all old `avianvisitorsHA` URLs automatically, and the README's new clone URL goes live the moment the rename lands.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_