### PR TITLE
Wall-display extras: clock, weather, view cycling, cursor hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,52 @@ window.AV_CONFIG = {
   // Sitting-or-flying: perched at/above this best-in-window confidence,
   // flight pose below it.
   sitConfidence: 0.96,
+
+  // Wall-mounted display extras - see the next section.
+  wall: {
+    clock: false,        // time + date, top right
+    weather: false,      // current conditions + sunrise/sunset from BirdNET-Go
+    fahrenheit: false,   // convert BirdNET-Go's Celsius for display
+    cycleSeconds: 0,     // auto-rotate collage -> stats -> atlas (0 = off)
+    hideCursor: false,   // hide the mouse cursor after 8s idle
+  },
 };
 ```
 
 The installer never overwrites an existing `config.js`.
+
+---
+
+## Wall-mounted displays
+
+The layout is fully responsive - the collage re-packs itself for any screen,
+portrait or landscape - so it already looks right on a hallway tablet or a
+TV. For a display that's *only* a bird dashboard, there are a few extras,
+styled to match the page (serif numerals over small letterspaced captions,
+following the light/dark theme):
+
+- **Clock** - time and date, top right.
+- **Weather** - current temperature, conditions, and sunrise/sunset, pulled
+  from BirdNET-Go's own weather support (yr.no by default, no API key, no
+  setup). If you've disabled weather in BirdNET-Go the widget just stays
+  hidden.
+- **View cycling** - rotate collage → stats → atlas every N seconds; any
+  touch pauses the rotation so passers-by can poke around.
+- **Cursor hiding** - the pointer disappears after 8 seconds idle.
+
+Turn them on for everyone in `config.js` (above), or - nicer - per display
+**from the URL**, so the same install serves your laptop plainly and the
+wall tablet fully dressed:
+
+```
+/local/habird/index.html?wall              clock + weather + cursor hiding
+/local/habird/index.html?wall&cycle=45     ...plus rotate views every 45s
+```
+
+Point your wall setup (a Webpage dashboard in kiosk mode, Fully Kiosk
+Browser, WallPanel, etc.) at the `?wall` URL and you're done. Dark theme
+suits evening rooms - toggle it once on the device (it's saved per
+browser).
 
 ---
 

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -3406,4 +3406,120 @@
     var s = readHash();
     if (s) highlightAtlas(s);
   };
+
+  // ===========================================================================
+  // Wall-display extras (HA build)
+  // ===========================================================================
+  // Opt-in widgets for wall-mounted dashboards: a clock, current weather
+  // (from BirdNET-Go's own weather endpoint, so no extra provider or key),
+  // automatic view cycling, and idle cursor hiding. Enabled per-install via
+  // config.js `wall: {...}`, or per-display via the URL - `?wall` turns on
+  // clock + weather + cursor hiding, `?cycle=45` rotates the views - so one
+  // install can serve both a desk browser and a kiosk.
+  (function wallDisplay() {
+    var WALL = AV_CFG.wall || {};
+    function urlFlag(name) {
+      return new RegExp('[?&]' + name + '(=|&|$)').test(location.search);
+    }
+    function urlNum(name) {
+      var m = location.search.match(new RegExp('[?&]' + name + '=(\\d+)'));
+      return m ? +m[1] : 0;
+    }
+    var wallOn      = urlFlag('wall');
+    var showClock   = !!WALL.clock || wallOn;
+    var showWeather = !!WALL.weather || wallOn;
+    var cycleSec    = urlNum('cycle') || +WALL.cycleSeconds || 0;
+    var hideCursor  = !!WALL.hideCursor || wallOn;
+
+    var wrap = document.getElementById('wallWidgets');
+    if (wrap && (showClock || showWeather)) wrap.hidden = false;
+
+    // ---- Clock ----
+    // Minute precision; re-renders on the minute boundary so it never
+    // drifts visibly. Locale decides 12/24h and date wording.
+    if (showClock && wrap) {
+      var clockEl = document.getElementById('wwClock');
+      var timeEl = document.getElementById('wwTime');
+      var dateEl = document.getElementById('wwDate');
+      clockEl.hidden = false;
+      var drawClock = function () {
+        var now = new Date();
+        timeEl.textContent = now.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        dateEl.textContent = now.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+        setTimeout(drawClock, (61 - now.getSeconds()) * 1000);
+      };
+      drawClock();
+    }
+
+    // ---- Weather ----
+    // BirdNET-Go records conditions alongside detections (yr.no by
+    // default). If its weather support is disabled the fetch fails and
+    // the block simply never shows. Values are metric at the source;
+    // wall.fahrenheit converts for display.
+    if (showWeather && wrap) {
+      var wxEl = document.getElementById('wwWeather');
+      var tempEl = document.getElementById('wwTemp');
+      var condEl = document.getElementById('wwCond');
+      var sunEl = document.getElementById('wwSun');
+      var hhmm = function (iso) {
+        var d = new Date(iso);
+        return isNaN(d) ? '' : d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      };
+      var drawWeather = function () {
+        bgJson('/weather/latest').then(function (j) {
+          var h = (j && j.hourly) || {};
+          if (typeof h.temperature !== 'number') return;
+          var t = WALL.fahrenheit ? (h.temperature * 9 / 5 + 32) : h.temperature;
+          tempEl.textContent = Math.round(t) + '°';
+          condEl.textContent = (h.weather_desc || h.weather_main || '').toLowerCase();
+          var daily = j.daily || {};
+          var rise = daily.sunrise ? hhmm(daily.sunrise) : '';
+          var set = daily.sunset ? hhmm(daily.sunset) : '';
+          sunEl.textContent = (rise && set) ? ('sun ' + rise + ' – ' + set) : '';
+          wxEl.hidden = false;
+          var rule = document.getElementById('wwRule');
+          if (rule && showClock) rule.hidden = false;
+        }).catch(function () { /* weather disabled in BirdNET-Go - stay hidden */ });
+      };
+      drawWeather();
+      setInterval(drawWeather, 10 * 60 * 1000);
+    }
+
+    // ---- View cycling ----
+    // Rotates collage -> stats -> atlas every cycleSec seconds. Any
+    // touch/click/keypress postpones the next hop so a passerby can
+    // poke around without the screen yanking away mid-look.
+    if (cycleSec > 0) {
+      var cycleT = null;
+      var armCycle = function () {
+        clearTimeout(cycleT);
+        cycleT = setTimeout(function () {
+          go((currentView + 1) % 3);
+          armCycle();
+        }, cycleSec * 1000);
+      };
+      ['pointerdown', 'keydown', 'touchstart'].forEach(function (ev) {
+        document.addEventListener(ev, armCycle, { passive: true });
+      });
+      armCycle();
+    }
+
+    // ---- Idle cursor hiding ----
+    // Kiosk browsers usually park the pointer dead-centre; hide it after
+    // 8s of stillness and bring it back on any movement.
+    if (hideCursor) {
+      var idleT = null;
+      var wake = function () {
+        document.body.classList.remove('ww-cursor-hidden');
+        clearTimeout(idleT);
+        idleT = setTimeout(function () {
+          document.body.classList.add('ww-cursor-hidden');
+        }, 8000);
+      };
+      ['pointermove', 'pointerdown', 'keydown'].forEach(function (ev) {
+        document.addEventListener(ev, wake, { passive: true });
+      });
+      wake();
+    }
+  })();
 })();

--- a/homeassistant/www/config.js
+++ b/homeassistant/www/config.js
@@ -20,4 +20,22 @@ window.AV_CONFIG = {
   // a loud, unmistakable bird is probably settled nearby - a faint,
   // uncertain one is just passing through.
   sitConfidence: 0.96,
+
+  // Wall-mounted display extras. All off by default for desk browsing.
+  //
+  // Tip: instead of (or in addition to) these, you can switch them on
+  // per-display from the URL, so one install serves both your laptop
+  // and the hallway tablet:
+  //   /local/habird/index.html?wall            clock + weather + cursor hiding
+  //   /local/habird/index.html?wall&cycle=45   ...plus rotate views every 45s
+  wall: {
+    clock: false,        // time + date, top right, matching the page style
+    weather: false,      // current conditions + sunrise/sunset, straight from
+                         // BirdNET-Go's weather support (yr.no by default -
+                         // no API key; hides itself if you've disabled it)
+    fahrenheit: false,   // BirdNET-Go reports Celsius; true converts for display
+    cycleSeconds: 0,     // auto-rotate collage -> stats -> atlas every N
+                         // seconds (0 = off); any touch postpones the hop
+    hideCursor: false,   // hide the mouse cursor after 8s idle (kiosks)
+  },
 };

--- a/homeassistant/www/index.html
+++ b/homeassistant/www/index.html
@@ -39,6 +39,21 @@
     <button data-h="168" type="button">7D</button>
     <button data-h="1000000" type="button">ALL</button>
   </div>
+  <!-- Wall-display widgets (clock / weather). Hidden unless enabled via
+       config.js (wall: {...}) or a ?wall query param - apt.js unhides and
+       populates them. Sits where the menu button was in the Pi build. -->
+  <div class="wall-widgets" id="wallWidgets" hidden>
+    <div class="ww-block" id="wwClock" hidden>
+      <span class="ww-big" id="wwTime">--:--</span>
+      <span class="ww-cap" id="wwDate"></span>
+    </div>
+    <i class="ww-rule" id="wwRule" hidden aria-hidden="true"></i>
+    <div class="ww-block" id="wwWeather" hidden>
+      <span class="ww-big" id="wwTemp"></span>
+      <span class="ww-cap" id="wwCond"></span>
+      <span class="ww-cap" id="wwSun"></span>
+    </div>
+  </div>
   <button class="menu-btn" id="menuBtn">menu</button>
 </header>
 

--- a/homeassistant/www/styles.css
+++ b/homeassistant/www/styles.css
@@ -1584,3 +1584,43 @@
  * See avian/forwarding/. */
 body.av-local #dd-locked { display: none; }
 body.av-local #dd-items  { display: block; }
+
+/* ============ Wall-display widgets (HA build) ============
+   Clock + weather in the top-right slot the Pi build's menu button
+   occupied. Same editorial recipe as the rest of the page: a serif
+   display line over a monospace, letterspaced micro-caption, all on
+   the paper/ink variables so the dark theme inverts for free. */
+.wall-widgets {
+  display: flex; align-items: center; gap: 18px;
+  text-align: right;
+}
+.wall-widgets[hidden] { display: none; }
+.ww-block { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; }
+.ww-block[hidden] { display: none; }
+.ww-big {
+  font: 600 clamp(20px, 2.3vw, 30px)/1 ui-serif, "Iowan Old Style", "Bookman Old Style", Georgia, serif;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+.ww-cap {
+  font: 9.5px/1.35 ui-monospace, Menlo, monospace;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.ww-cap:empty { display: none; }
+.ww-rule {
+  width: 1px; align-self: stretch;
+  background: var(--hairline);
+}
+.ww-rule[hidden] { display: none; }
+@media (max-width: 700px) {
+  .wall-widgets { gap: 12px; }
+  .ww-big { font-size: 17px; }
+  .ww-cap { font-size: 8px; letter-spacing: 0.1em; }
+  /* The sunrise/sunset caption is the first thing to go on a phone. */
+  #wwSun { display: none; }
+}
+/* Kiosk cursor hiding - applied to <body> by apt.js after idle when the
+   wall options ask for it. */
+body.ww-cursor-hidden, body.ww-cursor-hidden * { cursor: none !important; }


### PR DESCRIPTION
Opt-in extras for wall-mounted displays, all styled in the page's existing editorial recipe (serif numerals over monospace letterspaced captions, on the paper/ink CSS variables so the dark theme inverts them for free):

- **Clock** — time + date in the top-right slot the Pi build's menu button used to occupy; updates on the minute boundary, locale decides 12/24-hour.
- **Weather** — current temperature, conditions, and sunrise/sunset from BirdNET-Go's own `/api/v2/weather/latest` (yr.no by default — no API key, no setup). If weather is disabled in BirdNET-Go, the widget never appears. Optional `fahrenheit` display conversion.
- **View cycling** — rotate collage → stats → atlas every N seconds; any touch/click/keypress postpones the next hop.
- **Idle cursor hiding** for kiosk browsers (8s).

Everything is off by default. Enable per-install in `config.js` (`wall: {...}`) or — nicer — per display via URL params, so one install serves both a desk browser and the wall tablet:

```
/local/habird/index.html?wall              clock + weather + cursor hiding
/local/habird/index.html?wall&cycle=45     ...plus rotate views every 45s
```

README gains a **Wall-mounted displays** section (including a note that the layout is already fully responsive — the collage re-packs for any screen/orientation).

Tested with a jsdom run loading the page at `?wall&cycle=1` against a stubbed weather endpoint: clock and date render, 18.4°C displays as `18°` with "partly cloudy" and sun times, the divider appears, cycling advances to the stats view, and the existing default-mode smoke test still passes with widgets hidden.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_