### PR TITLE
Route the BirdNET-Go API through HA ingress on HTTPS (Nabu Casa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,14 @@ params to dress up a specific display.
 - **Nothing loads / console shows CORS errors.** BirdNET-Go allows all
   origins by default. If you've restricted `allowedorigins` in its security
   settings, add your HA origin (e.g. `http://homeassistant.local:8123`).
-- **Card loads but no data over Nabu Casa / HTTPS remote access.** The
-  browser blocks an `https://` page from calling the BirdNET-Go app's
-  plain-`http` API (mixed content). On the LAN over `http://` everything
-  works; for remote use you'd need the BirdNET-Go API behind HTTPS too
-  (e.g. a reverse proxy).
+- **Nabu Casa / HTTPS remote access.** There is no direct BirdNET-Go URL
+  that works remotely - the tunnel only carries HA itself, and browsers
+  block an `https://` page from calling a plain-`http` LAN address. The
+  card handles this automatically: on an HTTPS page it discovers the
+  add-on's **HA ingress** endpoint and routes the full API (audio
+  included) through it. Ingress discovery needs an admin HA user and the
+  default `birdnet_url` (leave it empty); if it can't be set up, data
+  still flows via the MQTT sensors - only audio playback is lost.
 - **No bird pictures.** The default artwork source is a CDN
   (`cdn.jsdelivr.net`), so the *browser viewing the dashboard* needs
   internet access. For offline/local-only setups use the `image_base`

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -85,9 +85,65 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
   var SIT_CONFIDENCE = (typeof AV_CFG.sitConfidence === 'number') ? AV_CFG.sitConfidence : 0.90;
 
   function bgUrl(path) { return BG_BASE + '/api/v2' + path; }
+
+  // ---- HTTPS / Nabu Casa: route the API through HA ingress ----
+  // Remote access tunnels only HA itself, and the browser blocks an
+  // https page from calling a plain-http LAN URL (mixed content) - so
+  // there is NO direct BirdNET-Go URL that works remotely. The add-on
+  // ships HA ingress though, which is same-origin with HA and rides the
+  // tunnel. When the page is https and a hass connection is available,
+  // discover the add-on's ingress endpoint, open an ingress session
+  // (cookie, renewed every 5 minutes), and rebase the API onto it -
+  // full functionality, audio included, from anywhere. Discovery needs
+  // an admin user (the supervisor API); anything failing here quietly
+  // leaves the LAN default in place and the MQTT fallback carries data.
+  var BG_READY = Promise.resolve();
+  if (!AV_CFG.birdnetGoUrl && location.protocol === 'https:' && AV_CFG.__getHass) {
+    BG_READY = (function () {
+      function ha(method, path, data) {
+        var hass = AV_CFG.__getHass();
+        if (!hass || !hass.callApi) return Promise.reject('no hass');
+        return Promise.resolve(hass.callApi(method, path, data));
+      }
+      function unwrap(res) { return (res && res.data) || res || {}; }
+      return ha('GET', 'hassio/addons').then(function (res) {
+        var addons = unwrap(res).addons || [];
+        var hit = addons.filter(function (a) {
+          return /birdnet/i.test(a.slug || '') || /birdnet/i.test(a.name || '');
+        })[0];
+        if (!hit) throw new Error('no birdnet add-on');
+        return ha('GET', 'hassio/addons/' + hit.slug + '/info');
+      }).then(function (res) {
+        var info = unwrap(res);
+        if (!info.ingress || !info.ingress_url) throw new Error('no ingress');
+        var base = String(info.ingress_url).replace(/\/+$/, '');
+        var session = null;
+        function newSession() {
+          return ha('POST', 'hassio/ingress/session').then(function (r) {
+            session = unwrap(r).session || null;
+            if (session) {
+              document.cookie = 'ingress_session=' + session +
+                ';path=/api/hassio_ingress/;SameSite=Strict;Secure';
+            }
+            return session;
+          });
+        }
+        return newSession().then(function (s) {
+          if (!s) throw new Error('no ingress session');
+          setInterval(function () {
+            ha('POST', 'hassio/ingress/validate_session', { session: session })
+              .catch(function () { newSession().catch(function () {}); });
+          }, 5 * 60 * 1000);
+          BG_BASE = base;
+        });
+      }).catch(function () { /* stay on the LAN default */ });
+    })();
+  }
+
   function bgJson(path) {
-    return fetch(bgUrl(path), { cache: 'no-store' })
-      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); });
+    return BG_READY.then(function () {
+      return fetch(bgUrl(path), { cache: 'no-store' });
+    }).then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); });
   }
   // Short-TTL memo so one refreshAll() fan-out (stats + lifelist + recent +
   // firstseen all want the species summary) costs one HTTP request, while a

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -155,7 +155,7 @@ app = app.replace(/\}\)\(\);\s*$/, '}\n');
 
 // Anything still touching `document.` must be on the whitelist.
 const leftover = [...app.matchAll(/document\.(\w+)/g)].map((m) => m[1]);
-const allowed = new Set(['createElement', 'fonts', 'hidden']);
+const allowed = new Set(['createElement', 'fonts', 'hidden', 'cookie']);
 const bad = leftover.filter((name) => !allowed.has(name));
 if (bad.length) throw new Error('unscoped document usage: ' + [...new Set(bad)].join(', '));
 

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -50,9 +50,65 @@
   var SIT_CONFIDENCE = (typeof AV_CFG.sitConfidence === 'number') ? AV_CFG.sitConfidence : 0.90;
 
   function bgUrl(path) { return BG_BASE + '/api/v2' + path; }
+
+  // ---- HTTPS / Nabu Casa: route the API through HA ingress ----
+  // Remote access tunnels only HA itself, and the browser blocks an
+  // https page from calling a plain-http LAN URL (mixed content) - so
+  // there is NO direct BirdNET-Go URL that works remotely. The add-on
+  // ships HA ingress though, which is same-origin with HA and rides the
+  // tunnel. When the page is https and a hass connection is available,
+  // discover the add-on's ingress endpoint, open an ingress session
+  // (cookie, renewed every 5 minutes), and rebase the API onto it -
+  // full functionality, audio included, from anywhere. Discovery needs
+  // an admin user (the supervisor API); anything failing here quietly
+  // leaves the LAN default in place and the MQTT fallback carries data.
+  var BG_READY = Promise.resolve();
+  if (!AV_CFG.birdnetGoUrl && location.protocol === 'https:' && AV_CFG.__getHass) {
+    BG_READY = (function () {
+      function ha(method, path, data) {
+        var hass = AV_CFG.__getHass();
+        if (!hass || !hass.callApi) return Promise.reject('no hass');
+        return Promise.resolve(hass.callApi(method, path, data));
+      }
+      function unwrap(res) { return (res && res.data) || res || {}; }
+      return ha('GET', 'hassio/addons').then(function (res) {
+        var addons = unwrap(res).addons || [];
+        var hit = addons.filter(function (a) {
+          return /birdnet/i.test(a.slug || '') || /birdnet/i.test(a.name || '');
+        })[0];
+        if (!hit) throw new Error('no birdnet add-on');
+        return ha('GET', 'hassio/addons/' + hit.slug + '/info');
+      }).then(function (res) {
+        var info = unwrap(res);
+        if (!info.ingress || !info.ingress_url) throw new Error('no ingress');
+        var base = String(info.ingress_url).replace(/\/+$/, '');
+        var session = null;
+        function newSession() {
+          return ha('POST', 'hassio/ingress/session').then(function (r) {
+            session = unwrap(r).session || null;
+            if (session) {
+              document.cookie = 'ingress_session=' + session +
+                ';path=/api/hassio_ingress/;SameSite=Strict;Secure';
+            }
+            return session;
+          });
+        }
+        return newSession().then(function (s) {
+          if (!s) throw new Error('no ingress session');
+          setInterval(function () {
+            ha('POST', 'hassio/ingress/validate_session', { session: session })
+              .catch(function () { newSession().catch(function () {}); });
+          }, 5 * 60 * 1000);
+          BG_BASE = base;
+        });
+      }).catch(function () { /* stay on the LAN default */ });
+    })();
+  }
+
   function bgJson(path) {
-    return fetch(bgUrl(path), { cache: 'no-store' })
-      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); });
+    return BG_READY.then(function () {
+      return fetch(bgUrl(path), { cache: 'no-store' });
+    }).then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); });
   }
   // Short-TTL memo so one refreshAll() fan-out (stats + lifelist + recent +
   // firstseen all want the species summary) costs one HTTP request, while a


### PR DESCRIPTION
Answers "what BirdNET-Go URL works over Nabu Casa?" — **none can**: the tunnel only carries HA itself, and browsers block an `https://` page from fetching any plain-`http` LAN address (mixed content). So instead of asking users for a URL that can't exist, the card now routes through **HA ingress**, which is same-origin with HA and rides the Nabu Casa tunnel.

## How it works
When the page is HTTPS, a `hass` connection exists, and `birdnet_url` is left empty, the card:
1. Finds the birdnet add-on via the supervisor API (`hassio/addons`, matched on slug/name).
2. Reads its `ingress_url` (`hassio/addons/<slug>/info` — the alexbelgium add-on ships `ingress: true`).
3. Opens an ingress session (`hassio/ingress/session`), sets the path-scoped session cookie, and revalidates it every 5 minutes (renewing on failure).
4. Rebases every API call onto `/api/hassio_ingress/<token>/api/v2/*` — **data, spectrograms, and audio all work remotely**.

Failure at any step (non-admin user, ingress unavailable) quietly keeps the LAN default, where the MQTT-history fallback carries the data as before — audio being the only loss.

## Testing
jsdom on an `https://….ui.nabu.casa` page with LAN fetches rejecting like a real mixed-content block: the add-on is discovered among others, a session is created, all 7 API calls of a boot cycle hit the ingress base, and the collage renders from them. All prior suites pass.

Real-world check worth doing: open the dashboard through your actual Nabu Casa link and confirm birds + audio load (the supervisor API shapes are stubbed faithfully but only your instance proves them).

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_