### PR TITLE
Production pass: XSS fix, performance, native editor, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 *A live bird collage card for Home Assistant, fed by BirdNET-Go.*
 
+[![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC_BY--NC--SA_4.0-lightgrey.svg)](LICENSE)
+
 <img alt="HABirdDashboard collage" src="docs/thumb.png" />
 
 A custom dashboard card for the data the
@@ -60,8 +63,8 @@ Home Assistant + BirdNET-Go.
 
 ## What you need
 
-- **Home Assistant OS or Supervised** - apps (add-ons) only exist on these
-  install types. Container/Core installs can still use the card; run
+- **Home Assistant OS or Supervised** - apps (formerly add-ons) only
+  exist on these install types. Container/Core installs can still use the card; run
   [BirdNET-Go](https://github.com/tphakala/birdnet-go) yourself (e.g. in
   Docker) and skip to [Step 3](#step-3--install-the-card).
 - **A microphone** the Home Assistant machine can hear birds with - a cheap
@@ -84,12 +87,12 @@ community repository, which you add once:
 
    [![Open your Home Assistant instance and add the alexbelgium repository.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Falexbelgium%2Fhassio-addons)
 
-   Or by hand: **Settings → Add-ons → Add-on Store** (HA is renaming these
-   "Apps") → **⋮ menu (top-right) → Repositories** → paste
+   Or by hand: **Settings → Apps** (called *Add-ons* before 2025) →
+   **⋮ menu (top-right) → Repositories** → paste
    `https://github.com/alexbelgium/hassio-addons` → **Add** → **Close**.
 
-2. Back in the store, search for **BirdNET-Go** (refresh the page if it
-   doesn't show up yet - it's under "Alexbelgium's Hass.io Add-ons").
+2. Back in the app store, search for **BirdNET-Go** (refresh the page if
+   it doesn't show up yet - it's under "Alexbelgium's Hass.io Add-ons").
 3. Open it and click **Install**. It's a large image; give it a few minutes.
 4. On the app's **Configuration** tab, set `TZ` to your timezone (this
    matters - the dashboard's time windows follow it), then **Save**.
@@ -218,7 +221,7 @@ becomes a real HA device you can use in automations (announce rare birds,
 light up a lamp for an owl...).
 
 1. **Broker**: install the official **Mosquitto broker** app (Settings →
-   Add-ons → Add-on Store - it's in the official store, no custom repo)
+   Apps - it's in the official catalog, no custom repository needed)
    and start it. HA will then offer the discovered **MQTT integration**
    under Settings → Devices & Services - add it.
 2. **Wire BirdNET-Go to the broker** - easiest way: on the BirdNET-Go
@@ -329,7 +332,7 @@ params to dress up a specific display.
   that works remotely - the tunnel only carries HA itself, and browsers
   block an `https://` page from calling a plain-`http` LAN address. The
   card handles this automatically: on an HTTPS page it discovers the
-  add-on's **HA ingress** endpoint and routes the full API (audio
+  app's **HA ingress** endpoint and routes the full API (audio
   included) through it. Ingress discovery needs an admin HA user and the
   default `birdnet_url` (leave it empty); if it can't be set up, data
   still flows via the MQTT sensors - only audio playback is lost.

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -34,7 +34,6 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     __resizeFns.forEach(function (fn) { try { fn(); } catch (e) {} });
   };
 
-  var PLACEHOLDER = [{"sci":"Calypte anna","com":"Anna's Hummingbird","featured":true},{"sci":"Passer domesticus","com":"House Sparrow"},{"sci":"Haemorhous mexicanus","com":"House Finch"},{"sci":"Turdus migratorius","com":"American Robin"},{"sci":"Zenaida macroura","com":"Mourning Dove"},{"sci":"Spinus psaltria","com":"Lesser Goldfinch"},{"sci":"Zonotrichia leucophrys","com":"White-crowned Sparrow"},{"sci":"Aphelocoma californica","com":"California Scrub-Jay"},{"sci":"Mimus polyglottos","com":"Northern Mockingbird"},{"sci":"Sayornis nigricans","com":"Black Phoebe"},{"sci":"Larus occidentalis","com":"Western Gull"},{"sci":"Corvus brachyrhynchos","com":"American Crow"}];
   // Bumped whenever the offline sketch build changes, so the browser
   // doesn't keep a stale cache after we regenerate the sketches.
   var SKETCH_VERSION = 'r10'; // full library restyle: every species
@@ -522,13 +521,16 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
             out.sort(function (a, b) { return a.t - b.t; });
             return out;
           }
-          // Latest value at (or just after - MQTT fan-out jitter) time t.
-          function valueAt(tl, t) {
-            var v = null;
-            for (var i = 0; i < tl.length; i++) {
-              if (tl[i].t <= t + 2000) v = tl[i].v; else break;
-            }
-            return v;
+          // Monotonic "latest value at time t (+2s MQTT fan-out jitter)"
+          // walker: the event streams are processed in ascending time, so
+          // a single advancing pointer replaces the old O(n^2) rescans -
+          // a 10-day busy-station history joins in linear time.
+          function walker(tl) {
+            var i = 0, last = null;
+            return function (t) {
+              while (i < tl.length && tl[i].t <= t + 2000) { last = tl[i].v; i++; }
+              return last;
+            };
           }
           function toConf(v) {
             var n = parseFloat(v);
@@ -539,19 +541,27 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
           sets.forEach(function (s) {
             var confs = timeline(s.conf);
             var scis = timeline(s.sci);
-            var coms = timeline(s.com);
+            var comAtA = walker(timeline(s.com));
+            var comAtB = walker(timeline(s.com));
+            var sciAt = walker(scis);
+            var confAt = walker(confs);
+            // 2-second buckets of (species, time) already emitted via the
+            // confidence stream, so the species pass can skip duplicates
+            // without scanning the whole event list per entry.
+            var seen = {};
             confs.forEach(function (c) {
-              var sci = valueAt(scis, c.t);
+              var sci = sciAt(c.t);
               if (!sci) return;
-              events.push({ t: c.t, sci: sci, com: valueAt(coms, c.t) || sci, conf: toConf(c.v) });
+              var b = Math.round(c.t / 2000);
+              seen[sci + '|' + (b - 1)] = 1;
+              seen[sci + '|' + b] = 1;
+              seen[sci + '|' + (b + 1)] = 1;
+              events.push({ t: c.t, sci: sci, com: comAtA(c.t) || sci, conf: toConf(c.v) });
             });
             scis.forEach(function (sc) {
-              var seen = events.some(function (e) {
-                return e.sci === sc.v && Math.abs(e.t - sc.t) < 2000;
-              });
-              if (seen) return;
-              events.push({ t: sc.t, sci: sc.v, com: valueAt(coms, sc.t) || sc.v,
-                conf: toConf(valueAt(confs, sc.t)) });
+              if (seen[sc.v + '|' + Math.round(sc.t / 2000)]) return;
+              events.push({ t: sc.t, sci: sc.v, com: comAtB(sc.t) || sc.v,
+                conf: toConf(confAt(sc.t)) });
             });
           });
           events.sort(function (a, b) { return a.t - b.t; });
@@ -1571,7 +1581,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
         var s = hit.data;
         var n = +s.n || 0;
         var noun = (n === 1) ? 'call' : 'calls';
-        tip.innerHTML = '<span class="ct-name">' + (s.com || s.sci) + '</span>'
+        tip.innerHTML = '<span class="ct-name">' + esc(s.com || s.sci) + '</span>'
           + '<span class="ct-w"> - </span>'
           + '<span class="ct-n">' + fmtN(n) + '</span>'
           + '<span class="ct-w"> ' + noun + ' ' + windowLabel(currentHours) + '</span>';
@@ -1650,10 +1660,19 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     if (el) el.innerHTML = '<span>' + label + '</span><span>' + (val == null || val === '' ? '-' : val) + '</span>';
   }
   function liRow(yr, label, ct, sci) {
-    var attr = sci ? ' data-sci="' + sci.replace(/"/g, '&quot;') + '"' : '';
-    return '<li' + attr + '><span class="yr">' + yr + '</span><span>' + label + '</span><span class="ct">' + (ct == null ? '-' : ct) + '</span></li>';
+    var attr = sci ? ' data-sci="' + esc(sci) + '"' : '';
+    return '<li' + attr + '><span class="yr">' + esc(yr) + '</span><span>' + esc(label) +
+      '</span><span class="ct">' + (ct == null ? '-' : esc(ct)) + '</span></li>';
   }
   function pad(n) { return n < 10 ? '0' + n : '' + n; }
+  // HTML-escape for every string interpolated into markup. Species names
+  // arrive from the BirdNET-Go API or MQTT sensor states - external data
+  // rendered inside the HA frontend, so it must never carry markup.
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
   function fmtN(n) {
     if (n == null) return '-';
     if (n >= 10000) return (n / 1000).toFixed(1) + 'k';
@@ -1869,9 +1888,9 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
       var n = +s.n || 0;
       var bottomPct = (n / maxN) * SPAN * 100;   // square height = quantity
       cols += ''
-        + '<div class="stats-tl-col" data-sci="' + s.sci + '" style="left:' + centerPct.toFixed(3) + '%;width:' + colW.toFixed(2) + 'px">'
+        + '<div class="stats-tl-col" data-sci="' + esc(s.sci) + '" style="left:' + centerPct.toFixed(3) + '%;width:' + colW.toFixed(2) + 'px">'
         +   '<div class="stats-tl-square" style="bottom:' + bottomPct.toFixed(1) + '%;width:' + sq.toFixed(1) + 'px;height:' + sq.toFixed(1) + 'px"></div>'
-        +   '<div class="stats-tl-label" style="bottom:calc(' + bottomPct.toFixed(1) + '% + ' + (sq + LABEL_GAP) + 'px)"><span class="com">' + (s.com || s.sci) + '</span><span class="sci">' + s.sci + '</span></div>'
+        +   '<div class="stats-tl-label" style="bottom:calc(' + bottomPct.toFixed(1) + '% + ' + (sq + LABEL_GAP) + 'px)"><span class="com">' + esc(s.com || s.sci) + '</span><span class="sci">' + esc(s.sci) + '</span></div>'
         + '</div>';
       var lab = fmtTs(parseTs(s.last_seen));
       if (lab) xaxis += '<span class="stats-tl-xtick" style="left:' + centerPct.toFixed(3) + '%">' + lab + '</span>';
@@ -1996,6 +2015,11 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
   var ICON_PLAY = '<svg viewBox="0 0 12 12" fill="currentColor"><path d="M3 2 L10 6 L3 10 Z"/></svg>';
   var ICON_PAUSE = '<svg viewBox="0 0 12 12" fill="currentColor"><rect x="3" y="2" width="2.5" height="8"/><rect x="6.5" y="2" width="2.5" height="8"/></svg>';
 
+  // Atlas playback state lives at module level: the grid is rebuilt when
+  // its data changes, and a per-render state would strand a playing clip
+  // (and stack duplicate grid-level listeners).
+  var currentAudio = null;
+  var currentBtn = null;
   function renderAtlas(animate) {
     var grid = __root.getElementById('atlasGrid');
     if (!grid) return;
@@ -2064,14 +2088,14 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
         : '<div><span class="n">' + fmtN(win) + '</span><span class="lbl-inline">' + windowLabel(currentHours) + '</span></div>'
           + '<div><span class="n">' + fmtN(total) + '</span><span class="lbl-inline">all time</span></div>';
       return ''
-        + '<article class="bird-card" data-sci="' + s.sci + '">'
+        + '<article class="bird-card" data-sci="' + esc(s.sci) + '">'
         +   (isLifer ? '<span class="lifer-badge" title="new to the life list in this window">lifer</span>' : '')
         +   '<div class="stat">' + statRows + '</div>'
         +   '<div class="img-wrap">'
-        +     '<img loading="lazy" decoding="async" src="' + sketchSrc + '" alt="' + s.com + '"' + birdImgAttrs(s.sci, 1) + '>'
+        +     '<img loading="lazy" decoding="async" src="' + sketchSrc + '" alt="' + esc(s.com) + '"' + birdImgAttrs(s.sci, 1) + '>'
         +   '</div>'
-        +   '<h3>' + s.com + '</h3>'
-        +   '<div class="sci">' + s.sci + '</div>'
+        +   '<h3>' + esc(s.com) + '</h3>'
+        +   '<div class="sci">' + esc(s.sci) + '</div>'
         +   '<div class="spectro-wrap" aria-hidden="true"></div>'
         +   '<div class="actions">'
         +     '<button type="button" class="chip play" data-action="play" aria-label="play recording">'
@@ -2097,8 +2121,6 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     //   for every card visible on initial render).
     // - If the recording endpoint 404s (no detection yet for this
     //   species), the button reverts and shows "no audio".
-    var currentAudio = null;
-    var currentBtn = null;
     function setBtnState(btn, state) {
       btn.setAttribute('data-state', state);
       if (state === 'playing') {
@@ -2225,6 +2247,10 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     });
 
     // Spectrogram click = scrub to that position (if playing) or restart.
+    // Wired once - the listener lives on the grid (which survives
+    // rebuilds) and reads the module-level playback state.
+    if (!grid.__scrubWired) {
+    grid.__scrubWired = true;
     grid.addEventListener('click', function (ev) {
       var sw = ev.target.closest && ev.target.closest('.spectro-wrap');
       if (!sw || !sw.firstChild) return;
@@ -2240,6 +2266,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
         btn.click();
       }
     });
+    }
     if (animate) playAtlasEntrance();
   }
 
@@ -3017,9 +3044,9 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
       __root.getElementById('modalRecCount').textContent = dets.length + ' captured';
       __root.getElementById('modalRecordings').innerHTML = dets.length
         ? dets.map(function (d) {
-            return '<li class="rec-row" data-file="' + (d.file || '') + '" data-date="' + (d.d || '') + '">'
+            return '<li class="rec-row" data-file="' + esc(d.file || '') + '" data-date="' + esc(d.d || '') + '">'
               + '<button class="play" type="button" aria-label="play">' + ICON_PLAY + '</button>'
-              + '<span class="when">' + fmtRecTime(d.d, d.t) + '<small>' + fmtDateLine(d.d, d.t) + '</small></span>'
+              + '<span class="when">' + esc(fmtRecTime(d.d, d.t)) + '<small>' + esc(fmtDateLine(d.d, d.t)) + '</small></span>'
               + '<span class="conf">' + ((+d.conf || 0) * 100).toFixed(0) + '%</span>'
               + '<div class="rec-spectro" aria-hidden="true">'
               +   '<div class="rec-spectro-loading">loading spectrogram...</div>'
@@ -4206,82 +4233,128 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
 // you copied the artwork locally (homeassistant/install.sh layout).
 var HABIRD_CDN_ASSETS = 'https://cdn.jsdelivr.net/gh/adamoberley/HABirdDashboard@HABirdDashboard/avian/assets/';
 
+var HABIRD_VERSION = '1.0.0';
+
 var HABIRD_EDITOR_SCHEMA = [
-  { name: 'view', selector: { select: { mode: 'dropdown', options: [
-    { value: 'collage', label: 'Collage' },
-    { value: 'stats', label: 'Stats' },
-    { value: 'atlas', label: 'Atlas' },
-  ] } } },
-  { name: 'view_selector', selector: { boolean: {} } },
+  { name: '', type: 'grid', schema: [
+    { name: 'view', selector: { select: { mode: 'dropdown', options: [
+      { value: 'collage', label: 'Collage' },
+      { value: 'stats', label: 'Stats' },
+      { value: 'atlas', label: 'Atlas' },
+    ] } } },
+    { name: 'window', selector: { select: { mode: 'dropdown', options: [
+      { value: '1', label: 'Last hour' },
+      { value: '12', label: 'Last 12 hours' },
+      { value: '24', label: 'Last 24 hours' },
+      { value: '72', label: 'Last 3 days' },
+      { value: '168', label: 'Last 7 days' },
+      { value: '336', label: 'Last 14 days' },
+      { value: '720', label: 'Last 30 days' },
+      { value: 'all', label: 'All time' },
+    ] } } },
+  ] },
   { name: 'title', selector: { text: {} } },
-  { name: 'window', selector: { select: { mode: 'dropdown', options: [
-    { value: '1', label: 'Last hour' },
-    { value: '12', label: 'Last 12 hours' },
-    { value: '24', label: 'Last 24 hours' },
-    { value: '72', label: 'Last 3 days' },
-    { value: '168', label: 'Last 7 days' },
-    { value: '336', label: 'Last 14 days' },
-    { value: '720', label: 'Last 30 days' },
-    { value: 'all', label: 'All time' },
-  ] } } },
-  { name: 'background', selector: { select: { mode: 'dropdown', options: [
-    { value: 'transparent', label: 'Transparent (blend with dashboard)' },
-    { value: 'paper', label: 'Paper (the collage\'s own ground)' },
-  ] } } },
-  { name: 'font', selector: { select: { mode: 'dropdown', options: [
-    { value: 'system', label: 'Home Assistant font' },
-    { value: 'serif', label: 'Editorial serif (the original look)' },
-  ] } } },
-  { name: 'birdnet_url', selector: { text: {} } },
-  { name: 'data_source', selector: { select: { mode: 'dropdown', options: [
-    { value: 'auto', label: 'Auto (BirdNET-Go API, fall back to MQTT history)' },
-    { value: 'api', label: 'BirdNET-Go API only' },
-    { value: 'ha', label: 'MQTT sensor history only' },
-  ] } } },
-  { name: 'history_days', selector: { number: { min: 1, max: 365, step: 1, mode: 'box', unit_of_measurement: 'days' } } },
-  { name: 'sit_confidence', selector: { number: { min: 0, max: 1.01, step: 0.01, mode: 'slider' } } },
-  { name: 'clock', selector: { boolean: {} } },
-  { name: 'weather', selector: { boolean: {} } },
-  { name: 'weather_entity', selector: { entity: { domain: 'weather' } } },
-  { name: 'corner', selector: { select: { mode: 'dropdown', options: [
-    { value: 'bottom-right', label: 'Bottom right' },
-    { value: 'bottom-left', label: 'Bottom left' },
-    { value: 'top-right', label: 'Top right' },
-    { value: 'top-left', label: 'Top left' },
-  ] } } },
-  { name: 'hide_cursor', selector: { boolean: {} } },
-  { name: 'theme', selector: { select: { mode: 'dropdown', options: [
-    { value: 'auto', label: 'Follow Home Assistant' },
-    { value: 'light', label: 'Light' },
-    { value: 'dark', label: 'Dark' },
-  ] } } },
-  { name: 'image_base', selector: { text: {} } },
-  { name: 'height', selector: { number: { min: 300, max: 2000, step: 10, mode: 'box', unit_of_measurement: 'px' } } },
+  { name: 'view_selector', selector: { boolean: {} } },
+  { name: 'appearance', type: 'expandable', flatten: true, title: 'Appearance', schema: [
+    { name: '', type: 'grid', schema: [
+      { name: 'background', selector: { select: { mode: 'dropdown', options: [
+        { value: 'transparent', label: 'Transparent' },
+        { value: 'paper', label: 'Paper' },
+      ] } } },
+      { name: 'font', selector: { select: { mode: 'dropdown', options: [
+        { value: 'system', label: 'Home Assistant' },
+        { value: 'serif', label: 'Editorial serif' },
+      ] } } },
+      { name: 'theme', selector: { select: { mode: 'dropdown', options: [
+        { value: 'auto', label: 'Follow Home Assistant' },
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+      ] } } },
+      { name: 'height', selector: { number: { min: 300, max: 2000, step: 10, mode: 'box', unit_of_measurement: 'px' } } },
+    ] },
+  ] },
+  { name: 'clockweather', type: 'expandable', flatten: true, title: 'Clock & weather', schema: [
+    { name: '', type: 'grid', schema: [
+      { name: 'clock', selector: { boolean: {} } },
+      { name: 'weather', selector: { boolean: {} } },
+    ] },
+    { name: 'weather_entity', selector: { entity: { domain: 'weather' } } },
+    { name: '', type: 'grid', schema: [
+      { name: 'corner', selector: { select: { mode: 'dropdown', options: [
+        { value: 'bottom-right', label: 'Bottom right' },
+        { value: 'bottom-left', label: 'Bottom left' },
+        { value: 'top-right', label: 'Top right' },
+        { value: 'top-left', label: 'Top left' },
+      ] } } },
+      { name: 'hide_cursor', selector: { boolean: {} } },
+    ] },
+  ] },
+  { name: 'birds', type: 'expandable', flatten: true, title: 'Birds & artwork', schema: [
+    { name: 'sit_confidence', selector: { number: { min: 0, max: 1.01, step: 0.01, mode: 'slider' } } },
+    { name: 'image_base', selector: { text: {} } },
+  ] },
+  { name: 'connection', type: 'expandable', flatten: true, title: 'Connection & data', schema: [
+    { name: 'birdnet_url', selector: { text: {} } },
+    { name: '', type: 'grid', schema: [
+      { name: 'data_source', selector: { select: { mode: 'dropdown', options: [
+        { value: 'auto', label: 'Automatic' },
+        { value: 'api', label: 'BirdNET-Go API only' },
+        { value: 'ha', label: 'MQTT history only' },
+      ] } } },
+      { name: 'history_days', selector: { number: { min: 1, max: 365, step: 1, mode: 'box', unit_of_measurement: 'days' } } },
+    ] },
+    { name: 'poll_seconds', selector: { number: { min: 10, max: 3600, step: 10, mode: 'box', unit_of_measurement: 's' } } },
+  ] },
 ];
 var HABIRD_LABELS = {
-  view: 'View this card shows',
-  view_selector: 'Show the collage/stats/atlas switcher',
-  title: 'Title (empty = none)',
+  view: 'View',
   window: 'Time window',
+  title: 'Title',
+  view_selector: 'Show the view switcher',
   background: 'Background',
   font: 'Font',
-  birdnet_url: 'BirdNET-Go URL (empty = this host, port 8080)',
-  data_source: 'Data source',
-  history_days: 'MQTT history span (bounded by recorder retention)',
-  sit_confidence: 'Sit confidence (perched at/above, flying below; 0 = always perched, 1.01 = always flying)',
-  clock: 'Clock',
-  weather: 'Weather (from your HA weather integration)',
-  weather_entity: 'Weather entity (empty = auto-detect)',
-  corner: 'Clock/weather corner',
-  hide_cursor: 'Hide cursor when idle (wall displays)',
   theme: 'Theme',
-  image_base: 'Artwork base URL (empty = CDN)',
-  height: 'Card height (empty = fill / 560px min)',
+  height: 'Height',
+  clock: 'Clock',
+  weather: 'Weather',
+  weather_entity: 'Weather entity',
+  corner: 'Corner',
+  hide_cursor: 'Hide idle cursor',
+  sit_confidence: 'Sit confidence',
+  image_base: 'Artwork base URL',
+  birdnet_url: 'BirdNET-Go URL',
+  data_source: 'Data source',
+  history_days: 'History span',
+  poll_seconds: 'Refresh interval',
+};
+var HABIRD_HELPERS = {
+  title: 'Optional heading. Birds pack around it, clock-style.',
+  view_selector: 'Turn off to lock this card to one view.',
+  height: 'Empty fills the available space (560 px minimum).',
+  weather_entity: 'Empty auto-detects your first weather entity.',
+  hide_cursor: 'For wall displays: pointer disappears after 8 s idle.',
+  sit_confidence: 'Birds perch at or above this detection confidence and fly below it. 0 = always perched, 1.01 = always flying.',
+  image_base: 'Empty loads artwork from the CDN. Use /local/habird-art/ for an offline copy.',
+  birdnet_url: 'Empty uses this host on port 8080, or HA ingress when remote.',
+  data_source: 'Automatic uses the API and falls back to the MQTT sensors.',
+  history_days: 'How far MQTT history reaches; bounded by recorder retention.',
+  poll_seconds: 'Safety-net refresh. MQTT pushes new detections instantly.',
 };
 
 class HABirdCard extends HTMLElement {
   setConfig(config) {
-    this._config = config || {};
+    config = config || {};
+    if (config.view && ['collage', 'stats', 'atlas'].indexOf(config.view) < 0) {
+      throw new Error("view must be 'collage', 'stats' or 'atlas'");
+    }
+    if (config.window && config.window !== 'all' && !(+config.window > 0)) {
+      throw new Error("window must be a positive number of hours or 'all'");
+    }
+    if (config.sit_confidence != null &&
+        (typeof config.sit_confidence !== 'number' || config.sit_confidence < 0 || config.sit_confidence > 1.01)) {
+      throw new Error('sit_confidence must be a number from 0 to 1.01');
+    }
+    this._config = config;
     if (this._config.height) this.style.height = Number(this._config.height) + 'px';
     else this.style.removeProperty('height');
     if (this._config.theme === 'dark') this.setAttribute('data-theme', 'dark');
@@ -4393,6 +4466,10 @@ class HABirdCard extends HTMLElement {
     if (this._ro) { this._ro.disconnect(); this._ro = null; }
   }
   getCardSize() { return 8; }
+  // Sections-view sizing: full width, tall by default, never crushed.
+  getGridOptions() {
+    return { columns: 'full', rows: 8, min_rows: 4 };
+  }
   static getStubConfig() {
     return { clock: true, weather: true, corner: 'bottom-right' };
   }
@@ -4412,6 +4489,7 @@ class HABirdCardEditor extends HTMLElement {
       // YAML editor still works.
       this._form = document.createElement('ha-form');
       this._form.computeLabel = function (s) { return HABIRD_LABELS[s.name] || s.name; };
+      this._form.computeHelper = function (s) { return HABIRD_HELPERS[s.name]; };
       var self = this;
       this._form.addEventListener('value-changed', function (ev) {
         var config = Object.assign({}, self._config, ev.detail.value);
@@ -4427,6 +4505,11 @@ class HABirdCardEditor extends HTMLElement {
   }
 }
 
+console.info(
+  '%c HABIRD-CARD %c v' + HABIRD_VERSION + ' ',
+  'background:#1a1612;color:#ece8e1;font-weight:700;border-radius:4px 0 0 4px;padding:2px 6px',
+  'background:#4a3f31;color:#ece8e1;border-radius:0 4px 4px 0;padding:2px 6px'
+);
 if (!customElements.get('habird-card')) customElements.define('habird-card', HABirdCard);
 if (!customElements.get('habird-card-editor')) customElements.define('habird-card-editor', HABirdCardEditor);
 window.customCards = window.customCards || [];

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -167,82 +167,128 @@ const wrapper = `
 // you copied the artwork locally (homeassistant/install.sh layout).
 var HABIRD_CDN_ASSETS = 'https://cdn.jsdelivr.net/gh/adamoberley/HABirdDashboard@HABirdDashboard/avian/assets/';
 
+var HABIRD_VERSION = '1.0.0';
+
 var HABIRD_EDITOR_SCHEMA = [
-  { name: 'view', selector: { select: { mode: 'dropdown', options: [
-    { value: 'collage', label: 'Collage' },
-    { value: 'stats', label: 'Stats' },
-    { value: 'atlas', label: 'Atlas' },
-  ] } } },
-  { name: 'view_selector', selector: { boolean: {} } },
+  { name: '', type: 'grid', schema: [
+    { name: 'view', selector: { select: { mode: 'dropdown', options: [
+      { value: 'collage', label: 'Collage' },
+      { value: 'stats', label: 'Stats' },
+      { value: 'atlas', label: 'Atlas' },
+    ] } } },
+    { name: 'window', selector: { select: { mode: 'dropdown', options: [
+      { value: '1', label: 'Last hour' },
+      { value: '12', label: 'Last 12 hours' },
+      { value: '24', label: 'Last 24 hours' },
+      { value: '72', label: 'Last 3 days' },
+      { value: '168', label: 'Last 7 days' },
+      { value: '336', label: 'Last 14 days' },
+      { value: '720', label: 'Last 30 days' },
+      { value: 'all', label: 'All time' },
+    ] } } },
+  ] },
   { name: 'title', selector: { text: {} } },
-  { name: 'window', selector: { select: { mode: 'dropdown', options: [
-    { value: '1', label: 'Last hour' },
-    { value: '12', label: 'Last 12 hours' },
-    { value: '24', label: 'Last 24 hours' },
-    { value: '72', label: 'Last 3 days' },
-    { value: '168', label: 'Last 7 days' },
-    { value: '336', label: 'Last 14 days' },
-    { value: '720', label: 'Last 30 days' },
-    { value: 'all', label: 'All time' },
-  ] } } },
-  { name: 'background', selector: { select: { mode: 'dropdown', options: [
-    { value: 'transparent', label: 'Transparent (blend with dashboard)' },
-    { value: 'paper', label: 'Paper (the collage\\'s own ground)' },
-  ] } } },
-  { name: 'font', selector: { select: { mode: 'dropdown', options: [
-    { value: 'system', label: 'Home Assistant font' },
-    { value: 'serif', label: 'Editorial serif (the original look)' },
-  ] } } },
-  { name: 'birdnet_url', selector: { text: {} } },
-  { name: 'data_source', selector: { select: { mode: 'dropdown', options: [
-    { value: 'auto', label: 'Auto (BirdNET-Go API, fall back to MQTT history)' },
-    { value: 'api', label: 'BirdNET-Go API only' },
-    { value: 'ha', label: 'MQTT sensor history only' },
-  ] } } },
-  { name: 'history_days', selector: { number: { min: 1, max: 365, step: 1, mode: 'box', unit_of_measurement: 'days' } } },
-  { name: 'sit_confidence', selector: { number: { min: 0, max: 1.01, step: 0.01, mode: 'slider' } } },
-  { name: 'clock', selector: { boolean: {} } },
-  { name: 'weather', selector: { boolean: {} } },
-  { name: 'weather_entity', selector: { entity: { domain: 'weather' } } },
-  { name: 'corner', selector: { select: { mode: 'dropdown', options: [
-    { value: 'bottom-right', label: 'Bottom right' },
-    { value: 'bottom-left', label: 'Bottom left' },
-    { value: 'top-right', label: 'Top right' },
-    { value: 'top-left', label: 'Top left' },
-  ] } } },
-  { name: 'hide_cursor', selector: { boolean: {} } },
-  { name: 'theme', selector: { select: { mode: 'dropdown', options: [
-    { value: 'auto', label: 'Follow Home Assistant' },
-    { value: 'light', label: 'Light' },
-    { value: 'dark', label: 'Dark' },
-  ] } } },
-  { name: 'image_base', selector: { text: {} } },
-  { name: 'height', selector: { number: { min: 300, max: 2000, step: 10, mode: 'box', unit_of_measurement: 'px' } } },
+  { name: 'view_selector', selector: { boolean: {} } },
+  { name: 'appearance', type: 'expandable', flatten: true, title: 'Appearance', schema: [
+    { name: '', type: 'grid', schema: [
+      { name: 'background', selector: { select: { mode: 'dropdown', options: [
+        { value: 'transparent', label: 'Transparent' },
+        { value: 'paper', label: 'Paper' },
+      ] } } },
+      { name: 'font', selector: { select: { mode: 'dropdown', options: [
+        { value: 'system', label: 'Home Assistant' },
+        { value: 'serif', label: 'Editorial serif' },
+      ] } } },
+      { name: 'theme', selector: { select: { mode: 'dropdown', options: [
+        { value: 'auto', label: 'Follow Home Assistant' },
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+      ] } } },
+      { name: 'height', selector: { number: { min: 300, max: 2000, step: 10, mode: 'box', unit_of_measurement: 'px' } } },
+    ] },
+  ] },
+  { name: 'clockweather', type: 'expandable', flatten: true, title: 'Clock & weather', schema: [
+    { name: '', type: 'grid', schema: [
+      { name: 'clock', selector: { boolean: {} } },
+      { name: 'weather', selector: { boolean: {} } },
+    ] },
+    { name: 'weather_entity', selector: { entity: { domain: 'weather' } } },
+    { name: '', type: 'grid', schema: [
+      { name: 'corner', selector: { select: { mode: 'dropdown', options: [
+        { value: 'bottom-right', label: 'Bottom right' },
+        { value: 'bottom-left', label: 'Bottom left' },
+        { value: 'top-right', label: 'Top right' },
+        { value: 'top-left', label: 'Top left' },
+      ] } } },
+      { name: 'hide_cursor', selector: { boolean: {} } },
+    ] },
+  ] },
+  { name: 'birds', type: 'expandable', flatten: true, title: 'Birds & artwork', schema: [
+    { name: 'sit_confidence', selector: { number: { min: 0, max: 1.01, step: 0.01, mode: 'slider' } } },
+    { name: 'image_base', selector: { text: {} } },
+  ] },
+  { name: 'connection', type: 'expandable', flatten: true, title: 'Connection & data', schema: [
+    { name: 'birdnet_url', selector: { text: {} } },
+    { name: '', type: 'grid', schema: [
+      { name: 'data_source', selector: { select: { mode: 'dropdown', options: [
+        { value: 'auto', label: 'Automatic' },
+        { value: 'api', label: 'BirdNET-Go API only' },
+        { value: 'ha', label: 'MQTT history only' },
+      ] } } },
+      { name: 'history_days', selector: { number: { min: 1, max: 365, step: 1, mode: 'box', unit_of_measurement: 'days' } } },
+    ] },
+    { name: 'poll_seconds', selector: { number: { min: 10, max: 3600, step: 10, mode: 'box', unit_of_measurement: 's' } } },
+  ] },
 ];
 var HABIRD_LABELS = {
-  view: 'View this card shows',
-  view_selector: 'Show the collage/stats/atlas switcher',
-  title: 'Title (empty = none)',
+  view: 'View',
   window: 'Time window',
+  title: 'Title',
+  view_selector: 'Show the view switcher',
   background: 'Background',
   font: 'Font',
-  birdnet_url: 'BirdNET-Go URL (empty = this host, port 8080)',
-  data_source: 'Data source',
-  history_days: 'MQTT history span (bounded by recorder retention)',
-  sit_confidence: 'Sit confidence (perched at/above, flying below; 0 = always perched, 1.01 = always flying)',
-  clock: 'Clock',
-  weather: 'Weather (from your HA weather integration)',
-  weather_entity: 'Weather entity (empty = auto-detect)',
-  corner: 'Clock/weather corner',
-  hide_cursor: 'Hide cursor when idle (wall displays)',
   theme: 'Theme',
-  image_base: 'Artwork base URL (empty = CDN)',
-  height: 'Card height (empty = fill / 560px min)',
+  height: 'Height',
+  clock: 'Clock',
+  weather: 'Weather',
+  weather_entity: 'Weather entity',
+  corner: 'Corner',
+  hide_cursor: 'Hide idle cursor',
+  sit_confidence: 'Sit confidence',
+  image_base: 'Artwork base URL',
+  birdnet_url: 'BirdNET-Go URL',
+  data_source: 'Data source',
+  history_days: 'History span',
+  poll_seconds: 'Refresh interval',
+};
+var HABIRD_HELPERS = {
+  title: 'Optional heading. Birds pack around it, clock-style.',
+  view_selector: 'Turn off to lock this card to one view.',
+  height: 'Empty fills the available space (560 px minimum).',
+  weather_entity: 'Empty auto-detects your first weather entity.',
+  hide_cursor: 'For wall displays: pointer disappears after 8 s idle.',
+  sit_confidence: 'Birds perch at or above this detection confidence and fly below it. 0 = always perched, 1.01 = always flying.',
+  image_base: 'Empty loads artwork from the CDN. Use /local/habird-art/ for an offline copy.',
+  birdnet_url: 'Empty uses this host on port 8080, or HA ingress when remote.',
+  data_source: 'Automatic uses the API and falls back to the MQTT sensors.',
+  history_days: 'How far MQTT history reaches; bounded by recorder retention.',
+  poll_seconds: 'Safety-net refresh. MQTT pushes new detections instantly.',
 };
 
 class HABirdCard extends HTMLElement {
   setConfig(config) {
-    this._config = config || {};
+    config = config || {};
+    if (config.view && ['collage', 'stats', 'atlas'].indexOf(config.view) < 0) {
+      throw new Error("view must be 'collage', 'stats' or 'atlas'");
+    }
+    if (config.window && config.window !== 'all' && !(+config.window > 0)) {
+      throw new Error("window must be a positive number of hours or 'all'");
+    }
+    if (config.sit_confidence != null &&
+        (typeof config.sit_confidence !== 'number' || config.sit_confidence < 0 || config.sit_confidence > 1.01)) {
+      throw new Error('sit_confidence must be a number from 0 to 1.01');
+    }
+    this._config = config;
     if (this._config.height) this.style.height = Number(this._config.height) + 'px';
     else this.style.removeProperty('height');
     if (this._config.theme === 'dark') this.setAttribute('data-theme', 'dark');
@@ -354,6 +400,10 @@ class HABirdCard extends HTMLElement {
     if (this._ro) { this._ro.disconnect(); this._ro = null; }
   }
   getCardSize() { return 8; }
+  // Sections-view sizing: full width, tall by default, never crushed.
+  getGridOptions() {
+    return { columns: 'full', rows: 8, min_rows: 4 };
+  }
   static getStubConfig() {
     return { clock: true, weather: true, corner: 'bottom-right' };
   }
@@ -373,6 +423,7 @@ class HABirdCardEditor extends HTMLElement {
       // YAML editor still works.
       this._form = document.createElement('ha-form');
       this._form.computeLabel = function (s) { return HABIRD_LABELS[s.name] || s.name; };
+      this._form.computeHelper = function (s) { return HABIRD_HELPERS[s.name]; };
       var self = this;
       this._form.addEventListener('value-changed', function (ev) {
         var config = Object.assign({}, self._config, ev.detail.value);
@@ -388,6 +439,11 @@ class HABirdCardEditor extends HTMLElement {
   }
 }
 
+console.info(
+  '%c HABIRD-CARD %c v' + HABIRD_VERSION + ' ',
+  'background:#1a1612;color:#ece8e1;font-weight:700;border-radius:4px 0 0 4px;padding:2px 6px',
+  'background:#4a3f31;color:#ece8e1;border-radius:0 4px 4px 0;padding:2px 6px'
+);
 if (!customElements.get('habird-card')) customElements.define('habird-card', HABirdCard);
 if (!customElements.get('habird-card-editor')) customElements.define('habird-card-editor', HABirdCardEditor);
 window.customCards = window.customCards || [];

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -1,5 +1,4 @@
 (function () {
-  var PLACEHOLDER = [{"sci":"Calypte anna","com":"Anna's Hummingbird","featured":true},{"sci":"Passer domesticus","com":"House Sparrow"},{"sci":"Haemorhous mexicanus","com":"House Finch"},{"sci":"Turdus migratorius","com":"American Robin"},{"sci":"Zenaida macroura","com":"Mourning Dove"},{"sci":"Spinus psaltria","com":"Lesser Goldfinch"},{"sci":"Zonotrichia leucophrys","com":"White-crowned Sparrow"},{"sci":"Aphelocoma californica","com":"California Scrub-Jay"},{"sci":"Mimus polyglottos","com":"Northern Mockingbird"},{"sci":"Sayornis nigricans","com":"Black Phoebe"},{"sci":"Larus occidentalis","com":"Western Gull"},{"sci":"Corvus brachyrhynchos","com":"American Crow"}];
   // Bumped whenever the offline sketch build changes, so the browser
   // doesn't keep a stale cache after we regenerate the sketches.
   var SKETCH_VERSION = 'r10'; // full library restyle: every species
@@ -487,13 +486,16 @@
             out.sort(function (a, b) { return a.t - b.t; });
             return out;
           }
-          // Latest value at (or just after - MQTT fan-out jitter) time t.
-          function valueAt(tl, t) {
-            var v = null;
-            for (var i = 0; i < tl.length; i++) {
-              if (tl[i].t <= t + 2000) v = tl[i].v; else break;
-            }
-            return v;
+          // Monotonic "latest value at time t (+2s MQTT fan-out jitter)"
+          // walker: the event streams are processed in ascending time, so
+          // a single advancing pointer replaces the old O(n^2) rescans -
+          // a 10-day busy-station history joins in linear time.
+          function walker(tl) {
+            var i = 0, last = null;
+            return function (t) {
+              while (i < tl.length && tl[i].t <= t + 2000) { last = tl[i].v; i++; }
+              return last;
+            };
           }
           function toConf(v) {
             var n = parseFloat(v);
@@ -504,19 +506,27 @@
           sets.forEach(function (s) {
             var confs = timeline(s.conf);
             var scis = timeline(s.sci);
-            var coms = timeline(s.com);
+            var comAtA = walker(timeline(s.com));
+            var comAtB = walker(timeline(s.com));
+            var sciAt = walker(scis);
+            var confAt = walker(confs);
+            // 2-second buckets of (species, time) already emitted via the
+            // confidence stream, so the species pass can skip duplicates
+            // without scanning the whole event list per entry.
+            var seen = {};
             confs.forEach(function (c) {
-              var sci = valueAt(scis, c.t);
+              var sci = sciAt(c.t);
               if (!sci) return;
-              events.push({ t: c.t, sci: sci, com: valueAt(coms, c.t) || sci, conf: toConf(c.v) });
+              var b = Math.round(c.t / 2000);
+              seen[sci + '|' + (b - 1)] = 1;
+              seen[sci + '|' + b] = 1;
+              seen[sci + '|' + (b + 1)] = 1;
+              events.push({ t: c.t, sci: sci, com: comAtA(c.t) || sci, conf: toConf(c.v) });
             });
             scis.forEach(function (sc) {
-              var seen = events.some(function (e) {
-                return e.sci === sc.v && Math.abs(e.t - sc.t) < 2000;
-              });
-              if (seen) return;
-              events.push({ t: sc.t, sci: sc.v, com: valueAt(coms, sc.t) || sc.v,
-                conf: toConf(valueAt(confs, sc.t)) });
+              if (seen[sc.v + '|' + Math.round(sc.t / 2000)]) return;
+              events.push({ t: sc.t, sci: sc.v, com: comAtB(sc.t) || sc.v,
+                conf: toConf(confAt(sc.t)) });
             });
           });
           events.sort(function (a, b) { return a.t - b.t; });
@@ -1536,7 +1546,7 @@
         var s = hit.data;
         var n = +s.n || 0;
         var noun = (n === 1) ? 'call' : 'calls';
-        tip.innerHTML = '<span class="ct-name">' + (s.com || s.sci) + '</span>'
+        tip.innerHTML = '<span class="ct-name">' + esc(s.com || s.sci) + '</span>'
           + '<span class="ct-w"> - </span>'
           + '<span class="ct-n">' + fmtN(n) + '</span>'
           + '<span class="ct-w"> ' + noun + ' ' + windowLabel(currentHours) + '</span>';
@@ -1615,10 +1625,19 @@
     if (el) el.innerHTML = '<span>' + label + '</span><span>' + (val == null || val === '' ? '-' : val) + '</span>';
   }
   function liRow(yr, label, ct, sci) {
-    var attr = sci ? ' data-sci="' + sci.replace(/"/g, '&quot;') + '"' : '';
-    return '<li' + attr + '><span class="yr">' + yr + '</span><span>' + label + '</span><span class="ct">' + (ct == null ? '-' : ct) + '</span></li>';
+    var attr = sci ? ' data-sci="' + esc(sci) + '"' : '';
+    return '<li' + attr + '><span class="yr">' + esc(yr) + '</span><span>' + esc(label) +
+      '</span><span class="ct">' + (ct == null ? '-' : esc(ct)) + '</span></li>';
   }
   function pad(n) { return n < 10 ? '0' + n : '' + n; }
+  // HTML-escape for every string interpolated into markup. Species names
+  // arrive from the BirdNET-Go API or MQTT sensor states - external data
+  // rendered inside the HA frontend, so it must never carry markup.
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
   function fmtN(n) {
     if (n == null) return '-';
     if (n >= 10000) return (n / 1000).toFixed(1) + 'k';
@@ -1834,9 +1853,9 @@
       var n = +s.n || 0;
       var bottomPct = (n / maxN) * SPAN * 100;   // square height = quantity
       cols += ''
-        + '<div class="stats-tl-col" data-sci="' + s.sci + '" style="left:' + centerPct.toFixed(3) + '%;width:' + colW.toFixed(2) + 'px">'
+        + '<div class="stats-tl-col" data-sci="' + esc(s.sci) + '" style="left:' + centerPct.toFixed(3) + '%;width:' + colW.toFixed(2) + 'px">'
         +   '<div class="stats-tl-square" style="bottom:' + bottomPct.toFixed(1) + '%;width:' + sq.toFixed(1) + 'px;height:' + sq.toFixed(1) + 'px"></div>'
-        +   '<div class="stats-tl-label" style="bottom:calc(' + bottomPct.toFixed(1) + '% + ' + (sq + LABEL_GAP) + 'px)"><span class="com">' + (s.com || s.sci) + '</span><span class="sci">' + s.sci + '</span></div>'
+        +   '<div class="stats-tl-label" style="bottom:calc(' + bottomPct.toFixed(1) + '% + ' + (sq + LABEL_GAP) + 'px)"><span class="com">' + esc(s.com || s.sci) + '</span><span class="sci">' + esc(s.sci) + '</span></div>'
         + '</div>';
       var lab = fmtTs(parseTs(s.last_seen));
       if (lab) xaxis += '<span class="stats-tl-xtick" style="left:' + centerPct.toFixed(3) + '%">' + lab + '</span>';
@@ -1961,6 +1980,11 @@
   var ICON_PLAY = '<svg viewBox="0 0 12 12" fill="currentColor"><path d="M3 2 L10 6 L3 10 Z"/></svg>';
   var ICON_PAUSE = '<svg viewBox="0 0 12 12" fill="currentColor"><rect x="3" y="2" width="2.5" height="8"/><rect x="6.5" y="2" width="2.5" height="8"/></svg>';
 
+  // Atlas playback state lives at module level: the grid is rebuilt when
+  // its data changes, and a per-render state would strand a playing clip
+  // (and stack duplicate grid-level listeners).
+  var currentAudio = null;
+  var currentBtn = null;
   function renderAtlas(animate) {
     var grid = document.getElementById('atlasGrid');
     if (!grid) return;
@@ -2029,14 +2053,14 @@
         : '<div><span class="n">' + fmtN(win) + '</span><span class="lbl-inline">' + windowLabel(currentHours) + '</span></div>'
           + '<div><span class="n">' + fmtN(total) + '</span><span class="lbl-inline">all time</span></div>';
       return ''
-        + '<article class="bird-card" data-sci="' + s.sci + '">'
+        + '<article class="bird-card" data-sci="' + esc(s.sci) + '">'
         +   (isLifer ? '<span class="lifer-badge" title="new to the life list in this window">lifer</span>' : '')
         +   '<div class="stat">' + statRows + '</div>'
         +   '<div class="img-wrap">'
-        +     '<img loading="lazy" decoding="async" src="' + sketchSrc + '" alt="' + s.com + '"' + birdImgAttrs(s.sci, 1) + '>'
+        +     '<img loading="lazy" decoding="async" src="' + sketchSrc + '" alt="' + esc(s.com) + '"' + birdImgAttrs(s.sci, 1) + '>'
         +   '</div>'
-        +   '<h3>' + s.com + '</h3>'
-        +   '<div class="sci">' + s.sci + '</div>'
+        +   '<h3>' + esc(s.com) + '</h3>'
+        +   '<div class="sci">' + esc(s.sci) + '</div>'
         +   '<div class="spectro-wrap" aria-hidden="true"></div>'
         +   '<div class="actions">'
         +     '<button type="button" class="chip play" data-action="play" aria-label="play recording">'
@@ -2062,8 +2086,6 @@
     //   for every card visible on initial render).
     // - If the recording endpoint 404s (no detection yet for this
     //   species), the button reverts and shows "no audio".
-    var currentAudio = null;
-    var currentBtn = null;
     function setBtnState(btn, state) {
       btn.setAttribute('data-state', state);
       if (state === 'playing') {
@@ -2190,6 +2212,10 @@
     });
 
     // Spectrogram click = scrub to that position (if playing) or restart.
+    // Wired once - the listener lives on the grid (which survives
+    // rebuilds) and reads the module-level playback state.
+    if (!grid.__scrubWired) {
+    grid.__scrubWired = true;
     grid.addEventListener('click', function (ev) {
       var sw = ev.target.closest && ev.target.closest('.spectro-wrap');
       if (!sw || !sw.firstChild) return;
@@ -2205,6 +2231,7 @@
         btn.click();
       }
     });
+    }
     if (animate) playAtlasEntrance();
   }
 
@@ -2982,9 +3009,9 @@
       document.getElementById('modalRecCount').textContent = dets.length + ' captured';
       document.getElementById('modalRecordings').innerHTML = dets.length
         ? dets.map(function (d) {
-            return '<li class="rec-row" data-file="' + (d.file || '') + '" data-date="' + (d.d || '') + '">'
+            return '<li class="rec-row" data-file="' + esc(d.file || '') + '" data-date="' + esc(d.d || '') + '">'
               + '<button class="play" type="button" aria-label="play">' + ICON_PLAY + '</button>'
-              + '<span class="when">' + fmtRecTime(d.d, d.t) + '<small>' + fmtDateLine(d.d, d.t) + '</small></span>'
+              + '<span class="when">' + esc(fmtRecTime(d.d, d.t)) + '<small>' + esc(fmtDateLine(d.d, d.t)) + '</small></span>'
               + '<span class="conf">' + ((+d.conf || 0) * 100).toFixed(0) + '%</span>'
               + '<div class="rec-spectro" aria-hidden="true">'
               +   '<div class="rec-spectro-loading">loading spectrogram...</div>'


### PR DESCRIPTION
Full review pass before going public — security, performance, HA-native polish, docs.

## Security (the blocker-grade finding, fixed)
**Stored XSS via species names.** Names arrive from the BirdNET-Go API and MQTT sensor states — external data rendered inside the HA frontend with the user's session — and were interpolated **unescaped** into `innerHTML` in the atlas cards, stats lists, timeline columns, hover tooltip, and modal recording rows. Anyone able to publish to the MQTT topic (or tamper with the BirdNET-Go DB) could have run script in HA. Every interpolation site now goes through a shared `esc()`, with a **regression test** feeding hostile `onerror`/`onload` payloads through both name fields and asserting they render as inert text with zero execution.

Rest of the audit came back clean: no `eval`/`new Function` in the shipped bundle; all `target="_blank"` links carry `rel="noopener"`; API paths URL-encoded; the ingress session cookie is path-scoped + `Secure`; the card holds no tokens (it rides the hass connection); the static page's `haToken` caveat was already documented; artwork slugs are `[a-z0-9-]` only.

## Performance
- **MQTT history join linearized**: monotonic two-pointer walkers replace O(n²) per-event timeline rescans, and a 2-second bucket set replaces the per-species full-list dedup scan — a 10-day busy-station history now joins in linear time.
- **Atlas playback state hoisted to module level**: grid rebuilds no longer strand a playing clip, and the grid-level scrub listener is wired once instead of accumulating a duplicate per rebuild (pre-existing leak).
- Dead placeholder demo data removed.

## HA-native polish
- **Card editor rebuilt to HA standards**: two-column grids, four expandable sections (Appearance / Clock & weather / Birds & artwork / Connection & data), short labels with helper text under each field (`computeHelper`), and `setConfig` validation that throws descriptive errors the way built-in cards surface config mistakes.
- Standard custom-card version banner on load (`HABIRD-CARD v1.0.0`), `getGridOptions` for sections-view sizing.

## Docs
- **"Apps" terminology** throughout (HA renamed add-ons): Settings → Apps with a "(called Add-ons before 2025)" note for older installs.
- HACS + license badges; install and MQTT walkthrough wording updated.

## Testing
All nine jsdom suites pass: card boot, look options, per-view + in-place modal, smooth updates, MQTT fallback + push, ingress routing, threshold extremes, static page, and the new XSS regression.

Remaining judgment for human eyes: the regrouped editor and helper text in the real dashboard editor UI.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_