### PR TITLE
Docs: RTSP cameras as bird mics + recommended analysis settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ Home Assistant + BirdNET-Go.
   exist on these install types. Container/Core installs can still use the card; run
   [BirdNET-Go](https://github.com/tphakala/birdnet-go) yourself (e.g. in
   Docker) and skip to [Step 3](#step-3--install-the-card).
-- **A microphone** the Home Assistant machine can hear birds with - a cheap
-  USB lavalier mic in a window works great.
+- **Something that can hear birds.** If you already have an outdoor
+  camera with a microphone - a doorbell, a security cam, an NVR - you're
+  done: BirdNET-Go listens to RTSP streams, so the camera you own becomes
+  the bird mic for free (Step 2 has the details). Otherwise a cheap USB
+  lavalier mic in a window works great.
 - About **20 minutes**.
 
 The whole setup is: install the BirdNET-Go app (the thing that listens and
@@ -103,11 +106,43 @@ community repository, which you add once:
 
 1. Open the BirdNET-Go web UI at `http://<your-ha-host>:8080` (there's also
    an **Open Web UI** button on the app page).
-2. In BirdNET-Go's **Settings**, set your **latitude/longitude** (so it
-   knows which species are plausible) and pick your **audio capture
-   device** - your USB mic should be listed.
-3. Wait for a bird (or play birdsong from your phone near the mic) and
+2. In BirdNET-Go's **Settings**, set your **latitude/longitude** so it
+   knows which species are plausible.
+3. Give it ears - either works, and you can mix several:
+
+   **An outdoor camera you already own (recommended).** Doorbell and
+   security cameras have microphones, and BirdNET-Go listens to RTSP
+   streams directly - no new hardware. In BirdNET-Go's audio settings add
+   an **RTSP stream** per camera: give it a name (it becomes that mic's
+   device name in HA, e.g. "Door Bell") and the camera's RTSP URL. Two
+   things to check on the camera side: **audio recording must be enabled**
+   in the camera's own settings, and use the low-resolution **sub stream**
+   - BirdNET-Go only wants the audio, no point pulling main-stream video.
+
+   For Reolink cameras behind an NVR the URL template is:
+
+   ```
+   rtsp://admin:PASSWORD@NVR.IP.ADDRESS:554/h264Preview_01_sub
+   ```
+
+   (`_01_` is the camera's channel number on the NVR - `_02_`, `_03_`...
+   for the rest; standalone Reolink cameras use the camera's own IP.)
+   Other brands publish similar RTSP paths - search "<brand> RTSP URL".
+
+   **Or a USB microphone** plugged into the HA machine - pick it as the
+   audio capture device.
+
+4. Wait for a bird (or play birdsong from your phone near the mic) and
    confirm detections appear on BirdNET-Go's own dashboard.
+
+**Tuning detections** - defaults are conservative; a starting point that
+has worked well in practice is **Settings → Analysis**: Confidence
+Threshold **0.7**, with Dynamic Threshold enabled, Trigger **0.9** and
+Minimum **0.5**. (Dynamic threshold temporarily lowers the bar for a
+species right after a high-confidence detection of it, so the quieter
+follow-up calls of a bird that's clearly present still get logged without
+letting random noise in.) It pairs nicely with this card's sit/fly rule -
+confident detections perch, borderline ones fly past.
 
 Don't move on until BirdNET-Go is detecting - this card is only a prettier
 window onto that data.


### PR DESCRIPTION
Docs: the setup guide assumed a USB microphone, but most HA users already own the better option — outdoor cameras with microphones.

## RTSP cameras as bird mics
Step 2 now leads with the camera path: add an **RTSP stream** per camera in BirdNET-Go's audio settings (the stream's name becomes that mic's HA device name — e.g. "Door Bell"), with the two camera-side gotchas called out: **audio recording must be enabled on the camera**, and use the low-res **sub stream** since only the audio matters. Includes the Reolink NVR template:

```
rtsp://admin:PASSWORD@NVR.IP.ADDRESS:554/h264Preview_01_sub
```

with the channel-number note (`_01_`/`_02_`/… per camera; standalone Reolinks use the camera's own IP) and a "search \<brand> RTSP URL" pointer for other makes. (Cleaned up the doubled `rtsp://` prefix from the original template.) "What you need" now says a camera you already own counts as the microphone — free, no new hardware.

## Recommended analysis settings
A field-tested tuning starting point under Step 2: **Settings → Analysis → Confidence Threshold 0.7, Dynamic Threshold enabled, Trigger 0.9 / Minimum 0.5**, with a one-line explanation of what dynamic threshold actually does (verified against birdnet-go's config: it temporarily lowers the per-species bar after a high-confidence detection so follow-up quieter calls still log). Framed as a starting point, not gospel, and tied to the card's sit/fly behavior.

Docs-only — no card changes.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_