### PR TITLE
User-facing name: Bird Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ window onto that data.
 
 1. In HACS: **⋮ menu (top-right) → Custom repositories**, add
    `https://github.com/adamoberley/HABirdDashboard` with type **Dashboard**.
-2. Search HACS for **HABird Card** and **Download** it.
+2. Search HACS for **Bird Card** and **Download** it.
 3. Reload your browser when prompted.
 
 **Without HACS:** download
@@ -163,7 +163,7 @@ the Terminal & SSH app), then **Settings → Dashboards → ⋮ → Resources �
 
 ## Step 4 — Add the card to a dashboard
 
-1. Edit any dashboard → **+ Add card** → search **HABird**.
+1. Edit any dashboard → **+ Add card** → search **Bird Card**.
 2. The visual editor has everything: BirdNET-Go URL (leave empty for the
    stock app on the same host), the sit/fly confidence slider, and toggles
    for the clock, weather, corner, theme, and cursor hiding.

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -4506,7 +4506,7 @@ class HABirdCardEditor extends HTMLElement {
 }
 
 console.info(
-  '%c HABIRD-CARD %c v' + HABIRD_VERSION + ' ',
+  '%c BIRD CARD %c v' + HABIRD_VERSION + ' ',
   'background:#1a1612;color:#ece8e1;font-weight:700;border-radius:4px 0 0 4px;padding:2px 6px',
   'background:#4a3f31;color:#ece8e1;border-radius:0 4px 4px 0;padding:2px 6px'
 );
@@ -4516,7 +4516,7 @@ window.customCards = window.customCards || [];
 if (!window.customCards.some(function (c) { return c.type === 'habird-card'; })) {
   window.customCards.push({
     type: 'habird-card',
-    name: 'HABird Card',
+    name: 'Bird Card',
     description: 'Live bird collage from your BirdNET-Go detections, with optional clock and weather.',
     documentationURL: 'https://github.com/adamoberley/HABirdDashboard',
   });

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "HABird Card",
+  "name": "Bird Card",
   "filename": "habird-card.js",
   "render_readme": true
 }

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -440,7 +440,7 @@ class HABirdCardEditor extends HTMLElement {
 }
 
 console.info(
-  '%c HABIRD-CARD %c v' + HABIRD_VERSION + ' ',
+  '%c BIRD CARD %c v' + HABIRD_VERSION + ' ',
   'background:#1a1612;color:#ece8e1;font-weight:700;border-radius:4px 0 0 4px;padding:2px 6px',
   'background:#4a3f31;color:#ece8e1;border-radius:0 4px 4px 0;padding:2px 6px'
 );
@@ -450,7 +450,7 @@ window.customCards = window.customCards || [];
 if (!window.customCards.some(function (c) { return c.type === 'habird-card'; })) {
   window.customCards.push({
     type: 'habird-card',
-    name: 'HABird Card',
+    name: 'Bird Card',
     description: 'Live bird collage from your BirdNET-Go detections, with optional clock and weather.',
     documentationURL: 'https://github.com/adamoberley/HABirdDashboard',
   });


### PR DESCRIPTION
"HABird Card" was redundant inside Home Assistant — everything there is HA. All user-facing surfaces now say **Bird Card**:

- the **card picker** entry (`customCards` name — also what "Add card" search matches),
- the **HACS listing** (`hacs.json`),
- the console banner,
- the README's install/add steps.

Deliberately unchanged: the element type stays **`custom:habird-card`** — renaming it would break every existing dashboard config, and a generic `bird-card` element name invites collisions with other custom cards in the registry. The repo keeps its HABirdDashboard name.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_