### PR TITLE
Docs: manual MQTT broker URL that actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,10 @@ light up a lamp for an owl...).
    and restart the app. It injects HA's broker address and credentials
    into BirdNET-Go for you.
    (Manual alternative: BirdNET-Go web UI → **Settings → Integrations →
-   MQTT**: enable it, broker `tcp://core-mosquitto:1883`, an HA username
-   + password, topic `birdnet`.)
+   MQTT**: enable it, set the broker to **`mqtt://<your-HA-IP>:1883`** -
+   e.g. `mqtt://192.168.1.2:1883` - with an HA username + password and
+   topic `birdnet`. Use the real IP: container hostnames like
+   `core-mosquitto` often don't resolve from inside the BirdNET-Go app.)
 3. **Turn on Home Assistant discovery**: in BirdNET-Go's web UI →
    **Settings → Integrations → MQTT**, enable the **Home Assistant**
    (auto-discovery) option. This is a separate toggle from MQTT itself,


### PR DESCRIPTION
Field-tested doc fix: the manual MQTT broker setting documented as `tcp://core-mosquitto:1883` doesn't work from inside the BirdNET-Go app — container hostnames like `core-mosquitto` often don't resolve there. The walkthrough now says what actually works:

```
mqtt://<your-HA-IP>:1883     e.g. mqtt://192.168.1.2:1883
```

with a note explaining why the hostname form fails. (`mqtt_auto_config` remains the recommended zero-typing path.)

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_