### PR TITLE
Ingress discovery hardening ("no path" fix) + v1.0.0 release prep

### DIFF
--- a/.github/ISSUE_TEMPLATE/artwork_request.yml
+++ b/.github/ISSUE_TEMPLATE/artwork_request.yml
@@ -1,0 +1,17 @@
+name: Artwork request
+description: Birds in your area are missing illustrations
+labels: [artwork]
+body:
+  - type: input
+    id: region
+    attributes:
+      label: Your eBird region code
+      description: e.g. US-NY, GB, DE-BY - find yours at https://ebird.org/explore
+      placeholder: US-NY
+    validations:
+      required: true
+  - type: textarea
+    id: species
+    attributes:
+      label: Species you're missing (optional)
+      description: Scientific or common names. Or generate them yourself - see "Missing artwork for your area?" in the README - and open a PR instead!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something in Bird Card isn't working right
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead? A screenshot is worth a hundred words here.
+    validations:
+      required: true
+  - type: dropdown
+    id: view
+    attributes:
+      label: Where?
+      options: [Collage, Stats, Atlas, Detail popup, Card editor, Setup/install]
+    validations:
+      required: true
+  - type: dropdown
+    id: access
+    attributes:
+      label: How do you open Home Assistant?
+      description: This matters a lot - several features route differently on HTTP vs HTTPS.
+      options: ["http:// on the LAN", "https:// (Nabu Casa / reverse proxy)", "Companion app", "Mix / not sure"]
+    validations:
+      required: true
+  - type: dropdown
+    id: source
+    attributes:
+      label: Data source (card option)
+      options: [auto (default), api, ha (MQTT history), not sure]
+  - type: input
+    id: card_version
+    attributes:
+      label: Bird Card version
+      description: Shown in the browser console as "BIRD CARD vX.Y.Z" when a dashboard loads.
+      placeholder: v1.0.0
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: "2026.6"
+  - type: input
+    id: bg_version
+    attributes:
+      label: BirdNET-Go app version
+      description: From the app's page in Settings → Apps.
+      placeholder: nightly-20260601
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors (if any)
+      description: Browser devtools console output, especially lines mentioning bird-card.
+      render: text

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,11 @@
+name: Feature request
+description: An idea for Bird Card
+labels: [enhancement]
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea
+      description: What would you like, and what's the situation where you'd use it?
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## v1.0.0 — 2026-06-11
+
+First public release of **Bird Card** (`custom:habird-card`), a live bird
+collage card for Home Assistant fed by BirdNET-Go.
+
+### The card
+- Silhouette-mask collage: every species heard in the configured window,
+  nested by actual bird outlines with no overlaps, sized by call count,
+  smooth reconciled updates (arrivals bloom in, departures fade out,
+  changes glide — no flashing rebuilds).
+- Sitting-or-flying poses by detection confidence (`sit_confidence`,
+  default 0.90; 0 = always perched, 1.01 = always flying).
+- Stats view (detection timeline + by-period / top species / first
+  detections) and Atlas view (field-guide grid with audio playback and
+  client-rendered spectrograms), each usable as a standalone card
+  (`view`, `view_selector`).
+- Detail popups in place over any view: recordings with scrubbable
+  spectrograms, Wikipedia description, genus/rarity, and a "not it?"
+  flag that writes a false-positive review back to BirdNET-Go.
+- Optional clock + weather (from your HA weather integration; BirdNET-Go
+  weather as fallback) living in a collage corner — birds pack around
+  them, and around a custom title, like they pack around each other.
+- Audio boost (default +24 dB through a compressor) for quiet clips.
+
+### Data
+- BirdNET-Go REST API v2 as the primary source; automatic fallback to
+  the recorder history of BirdNET-Go's MQTT sensors when the API is
+  unreachable; MQTT sensor updates push refreshes within ~1 second.
+- HTTPS pages (Nabu Casa) route the full API — audio included — through
+  HA ingress automatically.
+
+### Looks
+- Transparent background, HA system font, and HA light/dark by default —
+  all reversible per card (`background: paper`, `font: serif`,
+  `theme`). Layout responds to the card's own box via container queries.
+- Artwork lazy-loads per species from this repo's CDN; `image_base`
+  points at a local copy for offline installs; the generation pipeline
+  (`avian/scripts/`) renders style-matched art for any region — including
+  exactly your station's life list via `pregen.py --from-birdnet`.
+
+### Heritage
+Artwork, generation pipeline, and the silhouette-packing layout adapted
+from [AvianVisitors](https://github.com/Twarner491/AvianVisitors) by
+Teddy Warner under CC-BY-NC-SA-4.0.

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -97,31 +97,53 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
   // an admin user (the supervisor API); anything failing here quietly
   // leaves the LAN default in place and the MQTT fallback carries data.
   var _ingressP = null;
+  var _ingressWhy = '';
   function ingressApiBase() {
     if (_ingressP) return _ingressP;
-    if (!AV_CFG.__getHass) return (_ingressP = Promise.resolve(null));
+    if (!AV_CFG.__getHass) {
+      _ingressWhy = 'no hass connection';
+      return (_ingressP = Promise.resolve(null));
+    }
     _ingressP = (function () {
-      function ha(method, path, data) {
-        var hass = AV_CFG.__getHass();
-        if (!hass || !hass.callApi) return Promise.reject('no hass');
-        return Promise.resolve(hass.callApi(method, path, data));
-      }
       function unwrap(res) { return (res && res.data) || res || {}; }
-      return ha('GET', 'hassio/addons').then(function (res) {
-        var addons = unwrap(res).addons || [];
+      // Supervisor access, two channels: the REST proxy (/api/hassio/*)
+      // and, where that's unavailable, the WebSocket supervisor/api
+      // command modern frontends use.
+      function sup(method, path, data) {
+        var hass = AV_CFG.__getHass();
+        if (!hass) return Promise.reject('no hass');
+        var rest = hass.callApi
+          ? Promise.resolve(hass.callApi(method, 'hassio/' + path, data)).then(unwrap)
+          : Promise.reject('no callApi');
+        return rest.catch(function () {
+          if (!hass.callWS) return Promise.reject('no supervisor access');
+          return hass.callWS({
+            type: 'supervisor/api',
+            endpoint: '/' + path,
+            method: method.toLowerCase(),
+            data: data,
+          }).then(unwrap);
+        });
+      }
+      return sup('GET', 'addons').then(function (res) {
+        var addons = (res && res.addons) || [];
         var hit = addons.filter(function (a) {
           return /birdnet/i.test(a.slug || '') || /birdnet/i.test(a.name || '');
         })[0];
-        if (!hit) throw new Error('no birdnet add-on');
-        return ha('GET', 'hassio/addons/' + hit.slug + '/info');
-      }).then(function (res) {
-        var info = unwrap(res);
-        if (!info.ingress || !info.ingress_url) throw new Error('no ingress');
+        if (!hit) throw new Error('no birdnet add-on in the list');
+        return sup('GET', 'addons/' + hit.slug + '/info');
+      }, function () {
+        // Listing failed (older proxies restrict it) - probe the
+        // alexbelgium add-on's well-known slug directly; the repo hash
+        // prefix is stable across installs.
+        return sup('GET', 'addons/db21ed7f_birdnet-go/info');
+      }).then(function (info) {
+        if (!info.ingress || !info.ingress_url) throw new Error('add-on has no ingress');
         var base = String(info.ingress_url).replace(/\/+$/, '');
         var session = null;
         function newSession() {
-          return ha('POST', 'hassio/ingress/session').then(function (r) {
-            session = unwrap(r).session || null;
+          return sup('POST', 'ingress/session').then(function (r) {
+            session = (r && r.session) || null;
             if (session) {
               // NOTE: ';Secure' only over https - browsers silently DROP
               // JS-set Secure cookies on http pages, which would leave
@@ -137,14 +159,17 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
         return newSession().then(function (s) {
           if (!s) throw new Error('no ingress session');
           setInterval(function () {
-            ha('POST', 'hassio/ingress/validate_session', { session: session })
+            sup('POST', 'ingress/validate_session', { session: session })
               .catch(function () { newSession().catch(function () {}); });
           }, 5 * 60 * 1000);
+          _ingressWhy = '';
           return base;
         });
-      }).catch(function () {
-        // Transient failure (supervisor busy, hass not ready yet): don't
-        // poison the cache - let the next caller try again.
+      }).catch(function (e) {
+        // Remember WHY for the flag's error surface, and don't poison
+        // the cache - the next caller tries again.
+        _ingressWhy = (e && e.message) || String(e);
+        try { console.warn('[bird-card] ingress unavailable:', _ingressWhy); } catch (e2) {}
         _ingressP = null;
         return null;
       });
@@ -178,7 +203,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
       if (!sameOrigin) {
         // Cross-origin (direct LAN URL from the HA page): the browser
         // won't carry cookies, so CSRF can never pass. Needs ingress.
-        return Promise.reject('needs-ingress');
+        return Promise.reject('needs-ingress: ' + (_ingressWhy || 'unavailable'));
       }
       var base = ib || BG_BASE;
       var tok = getCookie('csrf');
@@ -4054,10 +4079,11 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
       }).catch(function (err) {
         flagBtn.disabled = false;
         // Tooltips don't exist on touch - put a short reason IN the pill.
-        var label = err === 'needs-ingress' ? 'no path'
+        var isPath = typeof err === 'string' && err.indexOf('needs-ingress') === 0;
+        var label = isPath ? 'no path'
           : (typeof err === 'number' ? 'err ' + err : 'failed');
-        var why = err === 'needs-ingress'
-          ? 'needs the HA ingress connection (admin user)'
+        var why = isPath
+          ? 'needs the HA ingress connection - ' + err.slice('needs-ingress: '.length)
           : 'BirdNET-Go refused (' + err + ')';
         try { console.warn('[bird-card] review write failed:', err); } catch (e) {}
         setFlag('failed', label, 'could not save: ' + why);

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -62,31 +62,53 @@
   // an admin user (the supervisor API); anything failing here quietly
   // leaves the LAN default in place and the MQTT fallback carries data.
   var _ingressP = null;
+  var _ingressWhy = '';
   function ingressApiBase() {
     if (_ingressP) return _ingressP;
-    if (!AV_CFG.__getHass) return (_ingressP = Promise.resolve(null));
+    if (!AV_CFG.__getHass) {
+      _ingressWhy = 'no hass connection';
+      return (_ingressP = Promise.resolve(null));
+    }
     _ingressP = (function () {
-      function ha(method, path, data) {
-        var hass = AV_CFG.__getHass();
-        if (!hass || !hass.callApi) return Promise.reject('no hass');
-        return Promise.resolve(hass.callApi(method, path, data));
-      }
       function unwrap(res) { return (res && res.data) || res || {}; }
-      return ha('GET', 'hassio/addons').then(function (res) {
-        var addons = unwrap(res).addons || [];
+      // Supervisor access, two channels: the REST proxy (/api/hassio/*)
+      // and, where that's unavailable, the WebSocket supervisor/api
+      // command modern frontends use.
+      function sup(method, path, data) {
+        var hass = AV_CFG.__getHass();
+        if (!hass) return Promise.reject('no hass');
+        var rest = hass.callApi
+          ? Promise.resolve(hass.callApi(method, 'hassio/' + path, data)).then(unwrap)
+          : Promise.reject('no callApi');
+        return rest.catch(function () {
+          if (!hass.callWS) return Promise.reject('no supervisor access');
+          return hass.callWS({
+            type: 'supervisor/api',
+            endpoint: '/' + path,
+            method: method.toLowerCase(),
+            data: data,
+          }).then(unwrap);
+        });
+      }
+      return sup('GET', 'addons').then(function (res) {
+        var addons = (res && res.addons) || [];
         var hit = addons.filter(function (a) {
           return /birdnet/i.test(a.slug || '') || /birdnet/i.test(a.name || '');
         })[0];
-        if (!hit) throw new Error('no birdnet add-on');
-        return ha('GET', 'hassio/addons/' + hit.slug + '/info');
-      }).then(function (res) {
-        var info = unwrap(res);
-        if (!info.ingress || !info.ingress_url) throw new Error('no ingress');
+        if (!hit) throw new Error('no birdnet add-on in the list');
+        return sup('GET', 'addons/' + hit.slug + '/info');
+      }, function () {
+        // Listing failed (older proxies restrict it) - probe the
+        // alexbelgium add-on's well-known slug directly; the repo hash
+        // prefix is stable across installs.
+        return sup('GET', 'addons/db21ed7f_birdnet-go/info');
+      }).then(function (info) {
+        if (!info.ingress || !info.ingress_url) throw new Error('add-on has no ingress');
         var base = String(info.ingress_url).replace(/\/+$/, '');
         var session = null;
         function newSession() {
-          return ha('POST', 'hassio/ingress/session').then(function (r) {
-            session = unwrap(r).session || null;
+          return sup('POST', 'ingress/session').then(function (r) {
+            session = (r && r.session) || null;
             if (session) {
               // NOTE: ';Secure' only over https - browsers silently DROP
               // JS-set Secure cookies on http pages, which would leave
@@ -102,14 +124,17 @@
         return newSession().then(function (s) {
           if (!s) throw new Error('no ingress session');
           setInterval(function () {
-            ha('POST', 'hassio/ingress/validate_session', { session: session })
+            sup('POST', 'ingress/validate_session', { session: session })
               .catch(function () { newSession().catch(function () {}); });
           }, 5 * 60 * 1000);
+          _ingressWhy = '';
           return base;
         });
-      }).catch(function () {
-        // Transient failure (supervisor busy, hass not ready yet): don't
-        // poison the cache - let the next caller try again.
+      }).catch(function (e) {
+        // Remember WHY for the flag's error surface, and don't poison
+        // the cache - the next caller tries again.
+        _ingressWhy = (e && e.message) || String(e);
+        try { console.warn('[bird-card] ingress unavailable:', _ingressWhy); } catch (e2) {}
         _ingressP = null;
         return null;
       });
@@ -143,7 +168,7 @@
       if (!sameOrigin) {
         // Cross-origin (direct LAN URL from the HA page): the browser
         // won't carry cookies, so CSRF can never pass. Needs ingress.
-        return Promise.reject('needs-ingress');
+        return Promise.reject('needs-ingress: ' + (_ingressWhy || 'unavailable'));
       }
       var base = ib || BG_BASE;
       var tok = getCookie('csrf');
@@ -4019,10 +4044,11 @@
       }).catch(function (err) {
         flagBtn.disabled = false;
         // Tooltips don't exist on touch - put a short reason IN the pill.
-        var label = err === 'needs-ingress' ? 'no path'
+        var isPath = typeof err === 'string' && err.indexOf('needs-ingress') === 0;
+        var label = isPath ? 'no path'
           : (typeof err === 'number' ? 'err ' + err : 'failed');
-        var why = err === 'needs-ingress'
-          ? 'needs the HA ingress connection (admin user)'
+        var why = isPath
+          ? 'needs the HA ingress connection - ' + err.slice('needs-ingress: '.length)
           : 'BirdNET-Go refused (' + err + ')';
         try { console.warn('[bird-card] review write failed:', err); } catch (e) {}
         setFlag('failed', label, 'could not save: ' + why);


### PR DESCRIPTION
Release prep + the "no path" fix, together:

## "No path" — ingress discovery hardened
The error meant the supervisor REST proxy call was failing on the real install, which killed ingress discovery and with it the review write. Three layers of fix:
- Every supervisor call (add-on list, add-on info, ingress session, session validation) now **falls back from the REST proxy to the WebSocket `supervisor/api` command** modern HA frontends use.
- If the add-on *list* is unavailable on both channels, the **alexbelgium add-on's well-known slug** (`db21ed7f_birdnet-go` — the repo-hash prefix is stable across installs) is probed directly.
- The failure **reason** is captured and surfaced — tooltip and `console.warn` now name the failed step instead of a bare "no path."

New jsdom suite proves the worst case: REST proxy dead + WS add-on list forbidden → discovery still succeeds via the WS known-slug probe and the review POST lands through the discovered ingress.

## v1.0.0 release prep
- **CHANGELOG.md** — the v1.0.0 feature summary, ready to paste as GitHub release notes.
- **Issue forms**: a bug report that collects up front everything this week's debugging needed (which view, http vs https access, data source mode, card/HA/BirdNET-Go versions, console output), a feature request, and an **artwork request** keyed on eBird region codes with a pointer to the self-serve pipeline.

All eleven suites pass.

After merging I'll push the `v1.0.0` tag; drafting the GitHub Release from it (attach `dist/habird-card.js`, paste the changelog) is a one-minute job in the UI.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_