### PR TITLE
HACS validation workflow + My-link install badge

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+# HACS validation - the same checks the default-store inclusion runs.
+# Required to pass (no errors, no ignores) before submitting to
+# hacs/default; the schedule keeps catching regressions after.
+name: Validate
+
+on:
+  push:
+    branches: [HABirdDashboard]
+  pull_request:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  hacs:
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: plugin

--- a/README.md
+++ b/README.md
@@ -158,7 +158,12 @@ window onto that data.
 
 ## Step 3 — Install the card
 
-**With HACS (recommended):**
+**With HACS (recommended):** click this to open the repository directly in
+your HACS:
+
+[![Open your Home Assistant instance and open this repository inside HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=adamoberley&repository=HABirdDashboard&category=plugin)
+
+Or by hand:
 
 1. In HACS: **⋮ menu (top-right) → Custom repositories**, add
    `https://github.com/adamoberley/HABirdDashboard` with type **Dashboard**.


### PR DESCRIPTION
Closes the two gaps from auditing against the HACS publishing requirements ([start](https://hacs.xyz/docs/publish/start/), [include](https://hacs.xyz/docs/publish/include/)):

1. **HACS Action workflow** (`.github/workflows/validate.yml`, `category: plugin`) — the include checklist requires this to pass *without errors or ignores* before submitting to `hacs/default`. Runs on push/PR plus a weekly schedule. It executes the same `hacs-validation` the inclusion bot runs, so its first run is also the authoritative answer on the repo-name/filename question (`hacs.json`'s `filename: habird-card.js` is the documented override for the default name-matching rule — and the working custom-repo install suggests it's honored).
2. **"My links"** — the docs ask publishers to add a my-link badge; Step 3 now opens with one that launches this repository directly inside the reader's own HACS (`category=plugin`, the backend name for Dashboard).

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_