### PR TITLE
v1.0.1 version bump for post-validation release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.0.1 — 2026-06-11
+
+- Reliability of the "not it?" false-positive flag on every access path
+  (http LAN, HTTPS/Nabu Casa): ingress session cookies, WebSocket
+  supervisor fallback with known-slug probe, and the ingress base
+  normalized to the token mount (fixes 405s; also restores full-API
+  remote routing with audio).
+- HACS validation workflow (green), My-link install badge, newcomer-first
+  README with pictures-first troubleshooting, issue forms.
+
 ## v1.0.0 — 2026-06-11
 
 First public release of **Bird Card** (`custom:habird-card`), a live bird

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -4485,7 +4485,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
 // you copied the artwork locally (homeassistant/install.sh layout).
 var HABIRD_CDN_ASSETS = 'https://cdn.jsdelivr.net/gh/adamoberley/HABirdDashboard@HABirdDashboard/avian/assets/';
 
-var HABIRD_VERSION = '1.0.0';
+var HABIRD_VERSION = '1.0.1';
 
 var HABIRD_EDITOR_SCHEMA = [
   { name: '', type: 'grid', schema: [

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -187,7 +187,7 @@ const wrapper = `
 // you copied the artwork locally (homeassistant/install.sh layout).
 var HABIRD_CDN_ASSETS = 'https://cdn.jsdelivr.net/gh/adamoberley/HABirdDashboard@HABirdDashboard/avian/assets/';
 
-var HABIRD_VERSION = '1.0.0';
+var HABIRD_VERSION = '1.0.1';
 
 var HABIRD_EDITOR_SCHEMA = [
   { name: '', type: 'grid', schema: [


### PR DESCRIPTION
Version bump to **v1.0.1** so a release can be published *after* the now-green HACS validation run — the `hacs/default` PR template requires affirming "I've created a new release after the validation actions were run successfully," and v1.0.0 (14:16) predates the green run (14:47). CHANGELOG gains the v1.0.1 entry (the flag-reliability chain + validation/badge/docs work since v1.0.0).

After merging: publish the **v1.0.1** release with the freshly built `dist/habird-card.js` attached, then submit to hacs/default.

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_