### PR TITLE
Docs: license badge that renders in HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *Bird Card: a live bird collage for Home Assistant, fed by BirdNET-Go.*
 
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC_BY--NC--SA_4.0-lightgrey.svg)](LICENSE)
+[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/license-CC_BY_NC_SA_4.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 <img alt="HABirdDashboard collage" src="https://raw.githubusercontent.com/adamoberley/HABirdDashboard/HABirdDashboard/docs/thumbnail.png" />
 


### PR DESCRIPTION
Fixes the broken "?" license badge on the HACS page. The badge URL used shields.io's double-hyphen escapes (`CC_BY--NC--SA_4.0`) which HACS's markdown rendering mangles — the dash-free HACS badge right beside it loaded fine from the same host, isolating the cause to those characters. Changes:

- Dash-free badge value (`license-CC_BY_NC_SA_4.0`, renders as "license | CC BY NC SA 4.0")
- Link target is now the canonical creativecommons.org license page instead of the relative `LICENSE` path, which also dead-ends inside HACS

https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyTLuG8tNd3CRGvZdWoJw)_