### PR TITLE
Raise the recording-boost ceiling to +48 dB

### DIFF
--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -4915,7 +4915,7 @@ var HABIRD_EDITOR_SCHEMA = [
     ] } } },
     { name: 'xeno_canto_key', selector: { text: {} } },
     { name: 'sit_confidence', selector: { number: { min: 0, max: 1.01, step: 0.01, mode: 'slider' } } },
-    { name: 'audio_boost', selector: { number: { min: 0, max: 24, step: 6, mode: 'slider', unit_of_measurement: 'dB' } } },
+    { name: 'audio_boost', selector: { number: { min: 0, max: 48, step: 6, mode: 'slider', unit_of_measurement: 'dB' } } },
     { name: 'image_base', selector: { text: {} } },
   ] },
   { name: 'connection', type: 'expandable', flatten: true, title: 'Connection & data', schema: [
@@ -4962,7 +4962,7 @@ var HABIRD_HELPERS = {
   weather_entity: 'Default (blank): the first weather.* entity found.',
   hide_cursor: 'For wall displays: pointer disappears after 8 s idle.',
   sit_confidence: 'Birds perch at or above this detection confidence and fly below it. 0 = always perched, 1.01 = always flying.',
-  audio_boost: "Detection clips are quiet; the boost is compressed so louder doesn't clip. 0 dB = off.",
+  audio_boost: "Detection clips are quiet; this boosts playback up to +48 dB (0 dB = off), compressed to curb clipping. Faint clips get much louder; the loudest can distort a little near the top - ease off if so.",
   tap_action: "What tapping a bird does. Default opens the info modal and plays the reference call. Call/both need a Xeno-Canto key; without one they fall back to just opening info.",
   xeno_canto_key: "Default (blank): reference calls off. A free key from xeno-canto.org/account turns them on - a clean example call to compare against your station's own captures.",
   collage_fill: 'How much of the card the flock fills (0.5 ≈ half, 1.0 ≈ nearly edge-to-edge). Busier days spread a little wider on their own. Birds always shrink to fit, so higher is safe.',

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -256,7 +256,7 @@ var HABIRD_EDITOR_SCHEMA = [
     ] } } },
     { name: 'xeno_canto_key', selector: { text: {} } },
     { name: 'sit_confidence', selector: { number: { min: 0, max: 1.01, step: 0.01, mode: 'slider' } } },
-    { name: 'audio_boost', selector: { number: { min: 0, max: 24, step: 6, mode: 'slider', unit_of_measurement: 'dB' } } },
+    { name: 'audio_boost', selector: { number: { min: 0, max: 48, step: 6, mode: 'slider', unit_of_measurement: 'dB' } } },
     { name: 'image_base', selector: { text: {} } },
   ] },
   { name: 'connection', type: 'expandable', flatten: true, title: 'Connection & data', schema: [
@@ -303,7 +303,7 @@ var HABIRD_HELPERS = {
   weather_entity: 'Default (blank): the first weather.* entity found.',
   hide_cursor: 'For wall displays: pointer disappears after 8 s idle.',
   sit_confidence: 'Birds perch at or above this detection confidence and fly below it. 0 = always perched, 1.01 = always flying.',
-  audio_boost: "Detection clips are quiet; the boost is compressed so louder doesn't clip. 0 dB = off.",
+  audio_boost: "Detection clips are quiet; this boosts playback up to +48 dB (0 dB = off), compressed to curb clipping. Faint clips get much louder; the loudest can distort a little near the top - ease off if so.",
   tap_action: "What tapping a bird does. Default opens the info modal and plays the reference call. Call/both need a Xeno-Canto key; without one they fall back to just opening info.",
   xeno_canto_key: "Default (blank): reference calls off. A free key from xeno-canto.org/account turns them on - a clean example call to compare against your station's own captures.",
   collage_fill: 'How much of the card the flock fills (0.5 ≈ half, 1.0 ≈ nearly edge-to-edge). Busier days spread a little wider on their own. Birds always shrink to fit, so higher is safe.',

--- a/homeassistant/www/config.js
+++ b/homeassistant/www/config.js
@@ -24,8 +24,10 @@ window.AV_CONFIG = {
   dataSource: 'auto',
   historyDays: 10,
 
-  // Recording playback boost in dB (0 = off). Routed through a
-  // compressor so louder doesn't mean clipped.
+  // Recording playback boost in dB, 0-48 (0 = off). Applied in the
+  // browser at playback and routed through a compressor that curbs
+  // clipping. Faint clips (weak mics) get much louder; at the top of
+  // the range the loudest clips can still distort a little.
   audioBoostDb: 24,
 
   // What a TAP on a bird does:


### PR DESCRIPTION
## What & why

Weak mics make detection clips faint, and the playback-boost slider **capped at +24 dB** — not enough headroom (you'd sit pinned at the max). This raises the card's `audio_boost` slider max from **24 → 48 dB** (still 6 dB steps).

The boost is applied **client-side at playback** (`makeAudio`: Web Audio gain → compressor), not by BirdNET-Go, so there's no server-side limit.

### Measured (`OfflineAudioContext`, 440 Hz sine)

| input | +24 dB (old max) | +48 dB (new max) |
|---|---|---|
| very weak (−40 dB) | −15.8 dB RMS | **−3.9 dB RMS**, clean |
| weak (−28 dB) | −7.0 dB RMS | −2.8 dB RMS, slight clip |
| loud (−16 dB) | −3.9 dB RMS, clean | −1.7 dB RMS, clips |

Faint clips — the weak-mic case — get **~12 dB louder and stay clean**. Only loud/close clips clip near the top of the range; the compressor curbs most of it but isn't a brick-wall limiter (a limiter retune was tested and didn't meaningfully help). The editor helper and `config.js` comment now state this trade-off, and the 6 dB steps let you settle at 36/42 if 48 ever distorts.

### Verification
- `npm test`: **13/13 suites pass**
- `dist/habird-card.js` rebuilt; slider shows `max: 48`

🤖 Generated with [Claude Code](https://claude.com/claude-code)