### PR TITLE
Collage: configurable bird spacing (card + Bird Frame)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- **Bird spacing control.** A `collageSpacing` slider (0–1, default 0.5) tunes
+  the gap between birds for any collage shape — lower packs them closer and a
+  touch bigger, higher gives more breathing room. They never overlap regardless
+  (the packer reserves each bird's footprint). Card editor, `config.js`
+  (+ `?spacing=` URL override), and the Bird Frame add-on.
 - **Ring "flow" — a wheeling flock.** In ring mode, every in-flight bird banks
   along the circle's tangent (nose around the ring, belly toward the centre),
   so the flock reads as one murmuration turning around the open middle - far-side

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ collage_shape: cluster       # cluster (one filled flock) | ring (birds scattere
 collage_hole: 0.5            # ring only: open-centre size 0.1-0.7 (bigger = a wider void)
 collage_flow: cw             # ring only: bank birds along the circle (a wheeling flock) - cw | ccw | off
 collage_flow_strength: 1     # ring flow strength 0-1 (1 = full head-to-tail wheel; lower = gentler bank)
+collage_spacing: 0.5         # gap between birds 0-1 (lower = closer/bigger, higher = airier; never overlap)
 tap_action: both             # both (open details + play call, default) |
                              #   info (details only) | call (reference call only)
 xeno_canto_key: ""           # free key from xeno-canto.org/account; enables the

--- a/addons/birdframe/DOCS.md
+++ b/addons/birdframe/DOCS.md
@@ -79,6 +79,7 @@ already look like a painting, so most setups change little. Most-touched:
 | `collage_hole` | Ring only: open-centre size (0.1–0.7 of the shorter side). Bigger = a more prominent void. |
 | `collage_flow` | Ring only: bank birds along the circle so the flock wheels around the centre — `cw` / `ccw` / `off`. |
 | `collage_flow_strength` | Ring flow strength (0–1). 1 = full wheel; lower = gentler bank. |
+| `collage_spacing` | Gap between birds (0–1, any shape). Lower = closer/bigger, higher = airier. They never overlap. |
 | `show_caption` | Off (default) = edge-to-edge art, no title. |
 | `window_hours` | Time window: `1`/`12`/`24`/`168`/`1000000` (ALL). |
 | `interval_minutes` | How often the collage refreshes on the TV. |

--- a/addons/birdframe/app/options.py
+++ b/addons/birdframe/app/options.py
@@ -39,6 +39,7 @@ class Options:
     collage_hole: float
     collage_flow: str
     collage_flow_strength: float
+    collage_spacing: float
     sit_confidence: float
     wall_clock: bool
     wall_weather: bool
@@ -103,6 +104,8 @@ def load() -> Options:
         # strength 0-1 scales from natural orientation to a full wheel.
         collage_flow=str(raw.get("collage_flow", "cw")).strip(),
         collage_flow_strength=float(raw.get("collage_flow_strength", 1.0)),
+        # Gap between birds (0-1, default 0.5); they never overlap regardless.
+        collage_spacing=float(raw.get("collage_spacing", 0.5)),
         sit_confidence=float(raw.get("sit_confidence", 0.90)),
         wall_clock=bool(raw.get("wall_clock", True)),
         wall_weather=bool(raw.get("wall_weather", True)),

--- a/addons/birdframe/app/server.py
+++ b/addons/birdframe/app/server.py
@@ -180,6 +180,7 @@ def _config_js(opts: Options, birdnet_url: str) -> bytes:
         # around the centre; strength scales natural->full wheel.
         "collageFlow": opts.collage_flow,
         "collageFlowStrength": opts.collage_flow_strength,
+        "collageSpacing": opts.collage_spacing,
         "sitConfidence": opts.sit_confidence,
         "audioBoostDb": 0,
         "tapAction": "info",

--- a/addons/birdframe/config.yaml
+++ b/addons/birdframe/config.yaml
@@ -58,6 +58,7 @@ options:
   collage_hole: 0.5
   collage_flow: "cw"
   collage_flow_strength: 1.0
+  collage_spacing: 0.5
   show_caption: false
   matte: "none"
   # --- What it shows ---
@@ -109,6 +110,9 @@ schema:
   collage_flow: "list(cw|ccw|off)"
   # How strictly birds align to the circle (0 = natural, 1 = full wheel).
   collage_flow_strength: "float(0,1)"
+  # Gap between birds (any shape; 0 = packed close, 0.5 = default, 1 = airy).
+  # They never overlap regardless - this only tunes the breathing room.
+  collage_spacing: "float(0,1)"
   # Show the small "Heard Recently" title (off = pure edge-to-edge art).
   show_caption: "bool"
   # TV border around the image: "none" fills the panel; a Samsung matte name

--- a/addons/birdframe/translations/en.yaml
+++ b/addons/birdframe/translations/en.yaml
@@ -61,6 +61,12 @@ configuration:
     description: >-
       How strictly birds align to the circle. 1 is a full head-to-tail wheel;
       lower keeps more of each bird's own pose for a gentler bank.
+  collage_spacing:
+    name: Bird spacing
+    description: >-
+      How much space sits between birds (any shape). They never overlap; lower
+      packs them closer and a touch bigger, higher gives more breathing room.
+      0.5 is the default.
   show_caption:
     name: Caption
     description: >-

--- a/addons/birdframe/www/apt.js
+++ b/addons/birdframe/www/apt.js
@@ -1775,9 +1775,18 @@
     var xBias = narrow ? 1 : T.ellipseAspectBias;
     var yBias = narrow ? 1.7 : 1;   // gentler than the desktop bias so the
                                     // portrait cluster stays a bit wider / less tall
-    // Tighten the breathing room as the flock grows: dense plates pack closer
-    // so each bird stays larger rather than shrinking to fit the gaps.
-    var basePad = nBirds > 90 ? 1 : nBirds > 45 ? 2 : COLLAGE_PAD;
+    // Spacing: user-tunable gap around each bird. Collision never lets birds
+    // overlap regardless; this only sets how much air sits between them - lower
+    // packs them closer (bigger, denser), higher gives more breathing room.
+    // collageSpacing 0-1 (0.5 = the default gap); ?spacing= overrides on the
+    // static page.
+    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0.5;
+    if (window.AV_CONFIG) {
+      var mSp = location.search.match(/[?&]spacing=([\d.]+)/);
+      if (mSp) spacing = parseFloat(mSp[1]);
+    }
+    spacing = Math.max(0, Math.min(1, spacing));
+    var basePad = Math.max(1, Math.round(spacing * 2 * COLLAGE_PAD));  // 0->1 tight, 0.5->3 default, 1->6 airy
     var pad = narrow ? Math.max(1, basePad - 1) : basePad;
     var placed = maskPack(tiles, W, H, xBias, yBias, pad, obstacles, ringMode);
 

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -1817,9 +1817,18 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     var xBias = narrow ? 1 : T.ellipseAspectBias;
     var yBias = narrow ? 1.7 : 1;   // gentler than the desktop bias so the
                                     // portrait cluster stays a bit wider / less tall
-    // Tighten the breathing room as the flock grows: dense plates pack closer
-    // so each bird stays larger rather than shrinking to fit the gaps.
-    var basePad = nBirds > 90 ? 1 : nBirds > 45 ? 2 : COLLAGE_PAD;
+    // Spacing: user-tunable gap around each bird. Collision never lets birds
+    // overlap regardless; this only sets how much air sits between them - lower
+    // packs them closer (bigger, denser), higher gives more breathing room.
+    // collageSpacing 0-1 (0.5 = the default gap); ?spacing= overrides on the
+    // static page.
+    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0.5;
+    if (window.AV_CONFIG) {
+      var mSp = location.search.match(/[?&]spacing=([\d.]+)/);
+      if (mSp) spacing = parseFloat(mSp[1]);
+    }
+    spacing = Math.max(0, Math.min(1, spacing));
+    var basePad = Math.max(1, Math.round(spacing * 2 * COLLAGE_PAD));  // 0->1 tight, 0.5->3 default, 1->6 airy
     var pad = narrow ? Math.max(1, basePad - 1) : basePad;
     var placed = maskPack(tiles, W, H, xBias, yBias, pad, obstacles, ringMode);
 
@@ -5129,6 +5138,7 @@ var HABIRD_EDITOR_SCHEMA = [
       { value: 'off', label: 'Off (natural)' },
     ] } } },
     { name: 'collage_flow_strength', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
+    { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
   ] },
   { name: 'birds', type: 'expandable', flatten: true, title: 'Birds & audio', schema: [
     { name: 'tap_action', selector: { select: { mode: 'dropdown', options: [
@@ -5180,6 +5190,7 @@ var HABIRD_LABELS = {
   collage_hole: 'Ring centre size',
   collage_flow: 'Ring flow (spin)',
   collage_flow_strength: 'Flow strength',
+  collage_spacing: 'Bird spacing',
   image_base: 'Artwork base URL',
   birdnet_url: 'BirdNET-Go URL',
   data_source: 'Data source',
@@ -5205,6 +5216,7 @@ var HABIRD_HELPERS = {
   collage_hole: 'Ring shape only: how big the open centre is, as a fraction of the card. Bigger = a wider gap and a thinner band of birds.',
   collage_flow: 'Ring shape only: bank each in-flight bird along the circle so the flock wheels around the centre, like a murmuration. Off keeps natural orientations.',
   collage_flow_strength: "How strictly birds align to the circle. 1 = a full head-to-tail wheel; lower keeps more of the natural pose.",
+  collage_spacing: 'How much space sits between birds (any shape). Birds never overlap; lower packs them closer and a touch bigger, higher gives more breathing room.',
   image_base: 'Default (blank): artwork from the CDN. Use /local/habird-art/ for an offline copy.',
   birdnet_url: 'Default (blank): this host on port 8080, or HA ingress when remote.',
   data_source: 'Automatic uses the API and falls back to the MQTT sensors.',
@@ -5325,6 +5337,9 @@ class HABirdCard extends HTMLElement {
       // 0-1 scales from natural orientation to a full wheel. Ignored unless ring.
       collageFlow: c.collage_flow || 'cw',
       collageFlowStrength: (typeof c.collage_flow_strength === 'number') ? c.collage_flow_strength : 1,
+      // Gap between birds (0-1, default 0.5). They never overlap; this only
+      // tunes breathing room. Applies to every collage shape.
+      collageSpacing: (typeof c.collage_spacing === 'number') ? c.collage_spacing : 0.5,
       audioBoostDb: (c.audio_boost == null ? 24 : +c.audio_boost),
       tapAction: c.tap_action || 'both',          // both | info | call
       xenoCantoKey: c.xeno_canto_key || '',        // enables reference calls

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -264,6 +264,7 @@ var HABIRD_EDITOR_SCHEMA = [
       { value: 'off', label: 'Off (natural)' },
     ] } } },
     { name: 'collage_flow_strength', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
+    { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
   ] },
   { name: 'birds', type: 'expandable', flatten: true, title: 'Birds & audio', schema: [
     { name: 'tap_action', selector: { select: { mode: 'dropdown', options: [
@@ -315,6 +316,7 @@ var HABIRD_LABELS = {
   collage_hole: 'Ring centre size',
   collage_flow: 'Ring flow (spin)',
   collage_flow_strength: 'Flow strength',
+  collage_spacing: 'Bird spacing',
   image_base: 'Artwork base URL',
   birdnet_url: 'BirdNET-Go URL',
   data_source: 'Data source',
@@ -340,6 +342,7 @@ var HABIRD_HELPERS = {
   collage_hole: 'Ring shape only: how big the open centre is, as a fraction of the card. Bigger = a wider gap and a thinner band of birds.',
   collage_flow: 'Ring shape only: bank each in-flight bird along the circle so the flock wheels around the centre, like a murmuration. Off keeps natural orientations.',
   collage_flow_strength: "How strictly birds align to the circle. 1 = a full head-to-tail wheel; lower keeps more of the natural pose.",
+  collage_spacing: 'How much space sits between birds (any shape). Birds never overlap; lower packs them closer and a touch bigger, higher gives more breathing room.',
   image_base: 'Default (blank): artwork from the CDN. Use /local/habird-art/ for an offline copy.',
   birdnet_url: 'Default (blank): this host on port 8080, or HA ingress when remote.',
   data_source: 'Automatic uses the API and falls back to the MQTT sensors.',
@@ -460,6 +463,9 @@ class HABirdCard extends HTMLElement {
       // 0-1 scales from natural orientation to a full wheel. Ignored unless ring.
       collageFlow: c.collage_flow || 'cw',
       collageFlowStrength: (typeof c.collage_flow_strength === 'number') ? c.collage_flow_strength : 1,
+      // Gap between birds (0-1, default 0.5). They never overlap; this only
+      // tunes breathing room. Applies to every collage shape.
+      collageSpacing: (typeof c.collage_spacing === 'number') ? c.collage_spacing : 0.5,
       audioBoostDb: (c.audio_boost == null ? 24 : +c.audio_boost),
       tapAction: c.tap_action || 'both',          // both | info | call
       xenoCantoKey: c.xeno_canto_key || '',        // enables reference calls

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -1775,9 +1775,18 @@
     var xBias = narrow ? 1 : T.ellipseAspectBias;
     var yBias = narrow ? 1.7 : 1;   // gentler than the desktop bias so the
                                     // portrait cluster stays a bit wider / less tall
-    // Tighten the breathing room as the flock grows: dense plates pack closer
-    // so each bird stays larger rather than shrinking to fit the gaps.
-    var basePad = nBirds > 90 ? 1 : nBirds > 45 ? 2 : COLLAGE_PAD;
+    // Spacing: user-tunable gap around each bird. Collision never lets birds
+    // overlap regardless; this only sets how much air sits between them - lower
+    // packs them closer (bigger, denser), higher gives more breathing room.
+    // collageSpacing 0-1 (0.5 = the default gap); ?spacing= overrides on the
+    // static page.
+    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0.5;
+    if (window.AV_CONFIG) {
+      var mSp = location.search.match(/[?&]spacing=([\d.]+)/);
+      if (mSp) spacing = parseFloat(mSp[1]);
+    }
+    spacing = Math.max(0, Math.min(1, spacing));
+    var basePad = Math.max(1, Math.round(spacing * 2 * COLLAGE_PAD));  // 0->1 tight, 0.5->3 default, 1->6 airy
     var pad = narrow ? Math.max(1, basePad - 1) : basePad;
     var placed = maskPack(tiles, W, H, xBias, yBias, pad, obstacles, ringMode);
 

--- a/homeassistant/www/config.js
+++ b/homeassistant/www/config.js
@@ -108,6 +108,12 @@ window.AV_CONFIG = {
   // bird's own pose for a gentler bank. URL override: ?strength=0.6
   collageFlowStrength: 1,
 
+  // Spacing (0 - 1): how much air sits between birds, for any shape. Birds
+  // never overlap regardless; this just tunes the gap. Lower packs them
+  // closer (denser, a touch bigger), higher gives more breathing room. 0.5
+  // is the default. URL override on the static page: ?spacing=0.3
+  collageSpacing: 0.5,
+
   // Paper background colour, per theme (hex). Left '', each theme uses its
   // built-in ground (near-white #fcfcfb light, charcoal #1a1a1a dark). Set
   // these to taste - e.g. a warm cream by day, a near-black by night - to make


### PR DESCRIPTION
## Configurable bird spacing

Adds a **`collageSpacing`** control (0–1, default `0.5`) so you can fine-tune how close the birds pack, for any collage shape:

- **lower** → packs them closer together (denser, a touch bigger)
- **higher** → more breathing room

Crucially, the packer always reserves each bird's full footprint — including its flow rotation — so **birds never overlap at any spacing value**; this only dials the air between them. (Verified at the tight end: `spacing=0.1` with 120 banked birds packs dense around the void with a clean gap around every one.)

### What changed
- `apt.js`: spacing maps to the silhouette-dilation `pad`, replacing the old fixed/count-tiered gap. Static page honours `?spacing=`.
- Card editor: **Bird spacing** slider + label/help + config mapping.
- `config.js` + the **Bird Frame** add-on (option → generated config, schema, translations, docs); renderer synced.
- README card-options + CHANGELOG.

Builds on the rotation-aware no-overlap fix already on `HABirdDashboard`. `npm test` → 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
