### PR TITLE
Collage ring: fix flipped cw/ccw, retune defaults, group ring settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## Unreleased
+## v1.2.1 — 2026-06-14
 
 ### Added
-- **Bird spacing control.** A `collageSpacing` slider (0–1, default 0.5) tunes
+- **Bird spacing control.** A `collageSpacing` slider (0–1, default 0 = tightest) tunes
   the gap between birds for any collage shape — lower packs them closer and a
   touch bigger, higher gives more breathing room. They never overlap regardless
   (the packer reserves each bird's footprint). Card editor, `config.js`
@@ -60,6 +60,13 @@
   `sizeContrast`).
 - **Recording-boost ceiling raised** from +24 dB to **+48 dB**
   (`audio_boost`) for quiet microphones.
+- **Card editor: a "Ring collage" section.** The ring-specific settings (shape,
+  centre size, flow direction + strength) now live in their own collapsible
+  group, separate from the general collage controls.
+
+### Fixed
+- **Ring flow direction was inverted** — "clockwise" wheeled counter-clockwise
+  and vice versa. Corrected so each matches its label.
 
 ### Added
 - **2K artwork + higher-res pipeline.** `pregen.py` gains

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ collage_shape: cluster       # cluster (one filled flock) | ring (birds scattere
 collage_hole: 0.5            # ring only: open-centre size 0.1-0.7 (bigger = a wider void)
 collage_flow: cw             # ring only: bank birds along the circle (a wheeling flock) - cw | ccw | off
 collage_flow_strength: 1     # ring flow strength 0-1 (1 = full head-to-tail wheel; lower = gentler bank)
-collage_spacing: 0.5         # gap between birds 0-1 (lower = closer/bigger, higher = airier; never overlap)
+collage_spacing: 0           # gap between birds 0-1 (0 = tightest/default, higher = airier; never overlap)
 tap_action: both             # both (open details + play call, default) |
                              #   info (details only) | call (reference call only)
 xeno_canto_key: ""           # free key from xeno-canto.org/account; enables the

--- a/addons/birdframe/app/options.py
+++ b/addons/birdframe/app/options.py
@@ -104,8 +104,8 @@ def load() -> Options:
         # strength 0-1 scales from natural orientation to a full wheel.
         collage_flow=str(raw.get("collage_flow", "cw")).strip(),
         collage_flow_strength=float(raw.get("collage_flow_strength", 1.0)),
-        # Gap between birds (0-1, default 0.5); they never overlap regardless.
-        collage_spacing=float(raw.get("collage_spacing", 0.5)),
+        # Gap between birds (0-1, default 0 = tightest); never overlap regardless.
+        collage_spacing=float(raw.get("collage_spacing", 0.0)),
         sit_confidence=float(raw.get("sit_confidence", 0.90)),
         wall_clock=bool(raw.get("wall_clock", True)),
         wall_weather=bool(raw.get("wall_weather", True)),

--- a/addons/birdframe/config.yaml
+++ b/addons/birdframe/config.yaml
@@ -58,7 +58,7 @@ options:
   collage_hole: 0.5
   collage_flow: "cw"
   collage_flow_strength: 1.0
-  collage_spacing: 0.5
+  collage_spacing: 0.0
   show_caption: false
   matte: "none"
   # --- What it shows ---
@@ -110,7 +110,7 @@ schema:
   collage_flow: "list(cw|ccw|off)"
   # How strictly birds align to the circle (0 = natural, 1 = full wheel).
   collage_flow_strength: "float(0,1)"
-  # Gap between birds (any shape; 0 = packed close, 0.5 = default, 1 = airy).
+  # Gap between birds (any shape; 0 = packed tight [default], 1 = airy).
   # They never overlap regardless - this only tunes the breathing room.
   collage_spacing: "float(0,1)"
   # Show the small "Heard Recently" title (off = pure edge-to-edge art).

--- a/addons/birdframe/translations/en.yaml
+++ b/addons/birdframe/translations/en.yaml
@@ -64,9 +64,9 @@ configuration:
   collage_spacing:
     name: Bird spacing
     description: >-
-      How much space sits between birds (any shape). They never overlap; lower
-      packs them closer and a touch bigger, higher gives more breathing room.
-      0.5 is the default.
+      How much space sits between birds (any shape). They never overlap; 0 (the
+      default) packs them tightest and a touch bigger, higher gives more
+      breathing room.
   show_caption:
     name: Caption
     description: >-

--- a/addons/birdframe/www/apt.js
+++ b/addons/birdframe/www/apt.js
@@ -1739,7 +1739,7 @@
         // rotated bird's wings sweep into a neighbour the collision never saw.
         headingDeg: (typeof headDeg === 'number') ? headDeg : null,
         flow: (flowOn && pose === 2 && typeof headDeg === 'number')
-          ? { dir: (flow === 'ccw') ? 1 : -1, strength: flowStrength } : null,
+          ? { dir: (flow === 'ccw') ? -1 : 1, strength: flowStrength } : null,
       };
     }).filter(Boolean);
 
@@ -1780,7 +1780,7 @@
     // packs them closer (bigger, denser), higher gives more breathing room.
     // collageSpacing 0-1 (0.5 = the default gap); ?spacing= overrides on the
     // static page.
-    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0.5;
+    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0;
     if (window.AV_CONFIG) {
       var mSp = location.search.match(/[?&]spacing=([\d.]+)/);
       if (mSp) spacing = parseFloat(mSp[1]);
@@ -1926,7 +1926,7 @@
       var head = DIRTAB[slugify(s.sci) + (r.pose === 2 ? '-2' : '')];
       if (flowOn && r.pose === 2 && typeof head === 'number') {
         var phi = Math.atan2(r.y + r.fullH / 2 - H / 2, r.x + r.fullW / 2 - W / 2) * 180 / Math.PI;
-        var dir = (flow === 'ccw') ? 1 : -1;
+        var dir = (flow === 'ccw') ? -1 : 1;
         var tau = phi + dir * 90;                          // nose rides the tangent
         var rightish = Math.cos(head * Math.PI / 180) >= 0;
         var flip = (dir === 1) ? !rightish : rightish;     // mirror if belly would face outward

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -1781,7 +1781,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
         // rotated bird's wings sweep into a neighbour the collision never saw.
         headingDeg: (typeof headDeg === 'number') ? headDeg : null,
         flow: (flowOn && pose === 2 && typeof headDeg === 'number')
-          ? { dir: (flow === 'ccw') ? 1 : -1, strength: flowStrength } : null,
+          ? { dir: (flow === 'ccw') ? -1 : 1, strength: flowStrength } : null,
       };
     }).filter(Boolean);
 
@@ -1822,7 +1822,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     // packs them closer (bigger, denser), higher gives more breathing room.
     // collageSpacing 0-1 (0.5 = the default gap); ?spacing= overrides on the
     // static page.
-    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0.5;
+    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0;
     if (window.AV_CONFIG) {
       var mSp = location.search.match(/[?&]spacing=([\d.]+)/);
       if (mSp) spacing = parseFloat(mSp[1]);
@@ -1968,7 +1968,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
       var head = DIRTAB[slugify(s.sci) + (r.pose === 2 ? '-2' : '')];
       if (flowOn && r.pose === 2 && typeof head === 'number') {
         var phi = Math.atan2(r.y + r.fullH / 2 - H / 2, r.x + r.fullW / 2 - W / 2) * 180 / Math.PI;
-        var dir = (flow === 'ccw') ? 1 : -1;
+        var dir = (flow === 'ccw') ? -1 : 1;
         var tau = phi + dir * 90;                          // nose rides the tangent
         var rightish = Math.cos(head * Math.PI / 180) >= 0;
         var flip = (dir === 1) ? !rightish : rightish;     // mirror if belly would face outward
@@ -5127,6 +5127,9 @@ var HABIRD_EDITOR_SCHEMA = [
     { name: 'collage_fill', selector: { number: { min: 0.1, max: 1, step: 0.05, mode: 'slider' } } },
     { name: 'size_contrast', selector: { number: { min: 0.2, max: 0.8, step: 0.05, mode: 'slider' } } },
     { name: 'paper_texture', selector: { number: { min: 0, max: 0.2, step: 0.01, mode: 'slider' } } },
+    { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
+  ] },
+  { name: 'ring', type: 'expandable', flatten: true, title: 'Ring collage', schema: [
     { name: 'collage_shape', selector: { select: { mode: 'dropdown', options: [
       { value: 'cluster', label: 'Cluster (filled)' },
       { value: 'ring', label: 'Ring (open centre)' },
@@ -5138,7 +5141,6 @@ var HABIRD_EDITOR_SCHEMA = [
       { value: 'off', label: 'Off (natural)' },
     ] } } },
     { name: 'collage_flow_strength', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
-    { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
   ] },
   { name: 'birds', type: 'expandable', flatten: true, title: 'Birds & audio', schema: [
     { name: 'tap_action', selector: { select: { mode: 'dropdown', options: [
@@ -5337,9 +5339,9 @@ class HABirdCard extends HTMLElement {
       // 0-1 scales from natural orientation to a full wheel. Ignored unless ring.
       collageFlow: c.collage_flow || 'cw',
       collageFlowStrength: (typeof c.collage_flow_strength === 'number') ? c.collage_flow_strength : 1,
-      // Gap between birds (0-1, default 0.5). They never overlap; this only
-      // tunes breathing room. Applies to every collage shape.
-      collageSpacing: (typeof c.collage_spacing === 'number') ? c.collage_spacing : 0.5,
+      // Gap between birds (0-1, default 0 = tightest). They never overlap; this
+      // only tunes breathing room. Applies to every collage shape.
+      collageSpacing: (typeof c.collage_spacing === 'number') ? c.collage_spacing : 0,
       audioBoostDb: (c.audio_boost == null ? 24 : +c.audio_boost),
       tapAction: c.tap_action || 'both',          // both | info | call
       xenoCantoKey: c.xeno_canto_key || '',        // enables reference calls

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -253,6 +253,9 @@ var HABIRD_EDITOR_SCHEMA = [
     { name: 'collage_fill', selector: { number: { min: 0.1, max: 1, step: 0.05, mode: 'slider' } } },
     { name: 'size_contrast', selector: { number: { min: 0.2, max: 0.8, step: 0.05, mode: 'slider' } } },
     { name: 'paper_texture', selector: { number: { min: 0, max: 0.2, step: 0.01, mode: 'slider' } } },
+    { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
+  ] },
+  { name: 'ring', type: 'expandable', flatten: true, title: 'Ring collage', schema: [
     { name: 'collage_shape', selector: { select: { mode: 'dropdown', options: [
       { value: 'cluster', label: 'Cluster (filled)' },
       { value: 'ring', label: 'Ring (open centre)' },
@@ -264,7 +267,6 @@ var HABIRD_EDITOR_SCHEMA = [
       { value: 'off', label: 'Off (natural)' },
     ] } } },
     { name: 'collage_flow_strength', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
-    { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
   ] },
   { name: 'birds', type: 'expandable', flatten: true, title: 'Birds & audio', schema: [
     { name: 'tap_action', selector: { select: { mode: 'dropdown', options: [
@@ -463,9 +465,9 @@ class HABirdCard extends HTMLElement {
       // 0-1 scales from natural orientation to a full wheel. Ignored unless ring.
       collageFlow: c.collage_flow || 'cw',
       collageFlowStrength: (typeof c.collage_flow_strength === 'number') ? c.collage_flow_strength : 1,
-      // Gap between birds (0-1, default 0.5). They never overlap; this only
-      // tunes breathing room. Applies to every collage shape.
-      collageSpacing: (typeof c.collage_spacing === 'number') ? c.collage_spacing : 0.5,
+      // Gap between birds (0-1, default 0 = tightest). They never overlap; this
+      // only tunes breathing room. Applies to every collage shape.
+      collageSpacing: (typeof c.collage_spacing === 'number') ? c.collage_spacing : 0,
       audioBoostDb: (c.audio_boost == null ? 24 : +c.audio_boost),
       tapAction: c.tap_action || 'both',          // both | info | call
       xenoCantoKey: c.xeno_canto_key || '',        // enables reference calls

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -1739,7 +1739,7 @@
         // rotated bird's wings sweep into a neighbour the collision never saw.
         headingDeg: (typeof headDeg === 'number') ? headDeg : null,
         flow: (flowOn && pose === 2 && typeof headDeg === 'number')
-          ? { dir: (flow === 'ccw') ? 1 : -1, strength: flowStrength } : null,
+          ? { dir: (flow === 'ccw') ? -1 : 1, strength: flowStrength } : null,
       };
     }).filter(Boolean);
 
@@ -1780,7 +1780,7 @@
     // packs them closer (bigger, denser), higher gives more breathing room.
     // collageSpacing 0-1 (0.5 = the default gap); ?spacing= overrides on the
     // static page.
-    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0.5;
+    var spacing = (typeof AV_CFG.collageSpacing === 'number') ? AV_CFG.collageSpacing : 0;
     if (window.AV_CONFIG) {
       var mSp = location.search.match(/[?&]spacing=([\d.]+)/);
       if (mSp) spacing = parseFloat(mSp[1]);
@@ -1926,7 +1926,7 @@
       var head = DIRTAB[slugify(s.sci) + (r.pose === 2 ? '-2' : '')];
       if (flowOn && r.pose === 2 && typeof head === 'number') {
         var phi = Math.atan2(r.y + r.fullH / 2 - H / 2, r.x + r.fullW / 2 - W / 2) * 180 / Math.PI;
-        var dir = (flow === 'ccw') ? 1 : -1;
+        var dir = (flow === 'ccw') ? -1 : 1;
         var tau = phi + dir * 90;                          // nose rides the tangent
         var rightish = Math.cos(head * Math.PI / 180) >= 0;
         var flip = (dir === 1) ? !rightish : rightish;     // mirror if belly would face outward

--- a/homeassistant/www/config.js
+++ b/homeassistant/www/config.js
@@ -109,10 +109,10 @@ window.AV_CONFIG = {
   collageFlowStrength: 1,
 
   // Spacing (0 - 1): how much air sits between birds, for any shape. Birds
-  // never overlap regardless; this just tunes the gap. Lower packs them
-  // closer (denser, a touch bigger), higher gives more breathing room. 0.5
-  // is the default. URL override on the static page: ?spacing=0.3
-  collageSpacing: 0.5,
+  // never overlap regardless; this just tunes the gap. 0 (the default) packs
+  // them tightest (densest, a touch bigger); higher gives more breathing room.
+  // URL override on the static page: ?spacing=0.3
+  collageSpacing: 0,
 
   // Paper background colour, per theme (hex). Left '', each theme uses its
   // built-in ground (near-white #fcfcfb light, charcoal #1a1a1a dark). Set


### PR DESCRIPTION
## Ring polish + v1.2.1 finalize

- **Fix flipped cw/ccw.** Ring flow "clockwise" was wheeling counter-clockwise and vice versa. Swapped the direction mapping in **both** the render and the rotation-aware collision so each matches its label. (Verified: `flow=cw` now wheels clockwise.)
- **Retuned defaults.** `collageSpacing` default `0.5 → 0` (packs tightest out of the box — birds still never overlap). Flow strength stays `1` (full wheel).
- **"Ring collage" editor group.** The ring-specific card settings — shape, centre size, flow direction + strength — moved into their own collapsible group, separate from the general collage controls (fill, size contrast, spacing).
- Defaults + docs synced across `config.js`, the Bird Frame add-on (`config.yaml`, translations), README, and DOCS. CHANGELOG stamped **v1.2.1**.

`npm test` → 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
