### PR TITLE
Size contrast: allow 0 for uniform bird sizes (1.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.2.3 — 2026-06-17
+
+### Changed
+- **Size contrast can now go all the way to 0.** The lower bound on the
+  `sizeContrast` control dropped from 0.2 to 0, so you can flatten the size
+  difference between common and rare birds completely — at 0 every bird is
+  drawn essentially the same size, regardless of how often it's heard. Wired
+  through the card editor slider, `config.js`, and the Bird Frame add-on
+  (`size_contrast` now accepts `0`–`0.8`). The default (0.5) is unchanged.
+
 ## v1.2.2 — 2026-06-14
 
 ### Fixed

--- a/addons/birdframe/app/options.py
+++ b/addons/birdframe/app/options.py
@@ -93,7 +93,8 @@ def load() -> Options:
         show_caption=bool(raw.get("show_caption", True)),
         window_hours=int(raw.get("window_hours", 24)),
         collage_fill=float(raw.get("collage_fill", 0.5)),
-        # How much bigger the most-heard birds draw than the rest (0.2-0.8).
+        # How much bigger the most-heard birds draw than the rest (0-0.8;
+        # 0 = all essentially the same size).
         size_contrast=float(raw.get("size_contrast", 0.5)),
         # Collage shape: "cluster" (one filled flock) or "ring" (birds scatter
         # across the frame around an open centre). collage_hole (0.1-0.7) sizes

--- a/addons/birdframe/config.yaml
+++ b/addons/birdframe/config.yaml
@@ -6,7 +6,7 @@
 # Frame TV's Art Mode - replacing the previous upload in place so the TV's art
 # library never accumulates duplicates.
 name: Bird Frame (Samsung Frame TV)
-version: "1.2.2"
+version: "1.2.3"
 slug: birdframe
 description: >-
   Render the live Bird collage and push it to a Samsung Frame TV as Art Mode
@@ -95,9 +95,10 @@ schema:
   paper_texture: "float(0,1)"
   # How much of the screen the flock claims (0.1-1.0).
   collage_fill: "float(0.1,1.0)"
-  # How much bigger the most-heard birds draw than the rest (0.2-0.8; lower =
-  # more even, higher = the loudest few dominate).
-  size_contrast: "float(0.2,0.8)"
+  # How much bigger the most-heard birds draw than the rest (0-0.8; lower =
+  # more even, 0 = all essentially the same size, higher = the loudest few
+  # dominate).
+  size_contrast: "float(0,0.8)"
   # Collage shape: "cluster" packs one filled flock; "ring" scatters the birds
   # across the whole frame around an open centre (the Avian Visitors poster
   # look). Ring fills best with a busy flock / long window.

--- a/addons/birdframe/www/apt.js
+++ b/addons/birdframe/www/apt.js
@@ -1313,9 +1313,10 @@
     // higher = the loudest birds dominate. User-tunable via sizeContrast
     // (card slider / config.js). At 0.5 the loudest bird reads a few times
     // bigger than a quiet one without dwarfing the flock; was a fixed 0.65,
-    // which made the top few birds feel oversized.
+    // which made the top few birds feel oversized. At 0 the exponent is 0,
+    // so every bird's score is 1 and the flock is drawn essentially uniform.
     var contrast = (typeof AV_CFG.sizeContrast === 'number') ? AV_CFG.sizeContrast : 0.5;
-    contrast = Math.max(0.2, Math.min(0.8, contrast));
+    contrast = Math.max(0, Math.min(0.8, contrast));
     return {
       countExp: contrast,
       // Floor: every species in the dataset must be visible, even

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -1355,9 +1355,10 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
     // higher = the loudest birds dominate. User-tunable via sizeContrast
     // (card slider / config.js). At 0.5 the loudest bird reads a few times
     // bigger than a quiet one without dwarfing the flock; was a fixed 0.65,
-    // which made the top few birds feel oversized.
+    // which made the top few birds feel oversized. At 0 the exponent is 0,
+    // so every bird's score is 1 and the flock is drawn essentially uniform.
     var contrast = (typeof AV_CFG.sizeContrast === 'number') ? AV_CFG.sizeContrast : 0.5;
-    contrast = Math.max(0.2, Math.min(0.8, contrast));
+    contrast = Math.max(0, Math.min(0.8, contrast));
     return {
       countExp: contrast,
       // Floor: every species in the dataset must be visible, even
@@ -5071,7 +5072,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
 // you copied the artwork locally (homeassistant/install.sh layout).
 var HABIRD_CDN_ASSETS = 'https://cdn.jsdelivr.net/gh/adamoberley/HABirdDashboard@HABirdDashboard/avian/assets/';
 
-var HABIRD_VERSION = '1.2.2';
+var HABIRD_VERSION = '1.2.3';
 
 var HABIRD_EDITOR_SCHEMA = [
   { name: 'dashboard', type: 'expandable', flatten: true, title: 'Dashboard', expanded: true, schema: [
@@ -5125,7 +5126,7 @@ var HABIRD_EDITOR_SCHEMA = [
     ] },
     { name: 'hide_cursor', selector: { boolean: {} } },
     { name: 'collage_fill', selector: { number: { min: 0.1, max: 1, step: 0.05, mode: 'slider' } } },
-    { name: 'size_contrast', selector: { number: { min: 0.2, max: 0.8, step: 0.05, mode: 'slider' } } },
+    { name: 'size_contrast', selector: { number: { min: 0, max: 0.8, step: 0.05, mode: 'slider' } } },
     { name: 'paper_texture', selector: { number: { min: 0, max: 0.2, step: 0.01, mode: 'slider' } } },
     { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
   ] },
@@ -5210,7 +5211,7 @@ var HABIRD_HELPERS = {
   tap_action: "What tapping a bird does. Default opens the info modal and plays the reference call. Call/both need a Xeno-Canto key; without one they fall back to just opening info.",
   xeno_canto_key: "Default (blank): reference calls off. A free key from xeno-canto.org/account turns them on - a clean example call to compare against your station's own captures.",
   collage_fill: 'How much of the card the flock fills (0.5 ≈ half, 1.0 ≈ nearly edge-to-edge). Busier days spread a little wider on their own. Birds always shrink to fit, so higher is safe.',
-  size_contrast: 'How much bigger your most-heard birds are drawn than the rest. Lower keeps every bird closer to the same size; higher lets the loudest few dominate.',
+  size_contrast: 'How much bigger your most-heard birds are drawn than the rest. Lower keeps every bird closer to the same size; 0 makes them all essentially the same size; higher lets the loudest few dominate.',
   paper_color: 'With Background: Paper, the page colour in light mode (hex, e.g. #f0e8d5). Blank uses the theme default (near-white).',
   paper_color_dark: 'With Background: Paper, the page colour in dark mode (hex, e.g. #15120d). Blank uses the theme default (charcoal).',
   paper_texture: 'With Background: Paper, a faint paper grain over the background (0 = off, ~0.06 = subtle), so it reads like a print on washi rather than flat colour.',

--- a/homeassistant/card/build.js
+++ b/homeassistant/card/build.js
@@ -197,7 +197,7 @@ const wrapper = `
 // you copied the artwork locally (homeassistant/install.sh layout).
 var HABIRD_CDN_ASSETS = 'https://cdn.jsdelivr.net/gh/adamoberley/HABirdDashboard@HABirdDashboard/avian/assets/';
 
-var HABIRD_VERSION = '1.2.2';
+var HABIRD_VERSION = '1.2.3';
 
 var HABIRD_EDITOR_SCHEMA = [
   { name: 'dashboard', type: 'expandable', flatten: true, title: 'Dashboard', expanded: true, schema: [
@@ -251,7 +251,7 @@ var HABIRD_EDITOR_SCHEMA = [
     ] },
     { name: 'hide_cursor', selector: { boolean: {} } },
     { name: 'collage_fill', selector: { number: { min: 0.1, max: 1, step: 0.05, mode: 'slider' } } },
-    { name: 'size_contrast', selector: { number: { min: 0.2, max: 0.8, step: 0.05, mode: 'slider' } } },
+    { name: 'size_contrast', selector: { number: { min: 0, max: 0.8, step: 0.05, mode: 'slider' } } },
     { name: 'paper_texture', selector: { number: { min: 0, max: 0.2, step: 0.01, mode: 'slider' } } },
     { name: 'collage_spacing', selector: { number: { min: 0, max: 1, step: 0.05, mode: 'slider' } } },
   ] },
@@ -336,7 +336,7 @@ var HABIRD_HELPERS = {
   tap_action: "What tapping a bird does. Default opens the info modal and plays the reference call. Call/both need a Xeno-Canto key; without one they fall back to just opening info.",
   xeno_canto_key: "Default (blank): reference calls off. A free key from xeno-canto.org/account turns them on - a clean example call to compare against your station's own captures.",
   collage_fill: 'How much of the card the flock fills (0.5 ≈ half, 1.0 ≈ nearly edge-to-edge). Busier days spread a little wider on their own. Birds always shrink to fit, so higher is safe.',
-  size_contrast: 'How much bigger your most-heard birds are drawn than the rest. Lower keeps every bird closer to the same size; higher lets the loudest few dominate.',
+  size_contrast: 'How much bigger your most-heard birds are drawn than the rest. Lower keeps every bird closer to the same size; 0 makes them all essentially the same size; higher lets the loudest few dominate.',
   paper_color: 'With Background: Paper, the page colour in light mode (hex, e.g. #f0e8d5). Blank uses the theme default (near-white).',
   paper_color_dark: 'With Background: Paper, the page colour in dark mode (hex, e.g. #15120d). Blank uses the theme default (charcoal).',
   paper_texture: 'With Background: Paper, a faint paper grain over the background (0 = off, ~0.06 = subtle), so it reads like a print on washi rather than flat colour.',

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -1313,9 +1313,10 @@
     // higher = the loudest birds dominate. User-tunable via sizeContrast
     // (card slider / config.js). At 0.5 the loudest bird reads a few times
     // bigger than a quiet one without dwarfing the flock; was a fixed 0.65,
-    // which made the top few birds feel oversized.
+    // which made the top few birds feel oversized. At 0 the exponent is 0,
+    // so every bird's score is 1 and the flock is drawn essentially uniform.
     var contrast = (typeof AV_CFG.sizeContrast === 'number') ? AV_CFG.sizeContrast : 0.5;
-    contrast = Math.max(0.2, Math.min(0.8, contrast));
+    contrast = Math.max(0, Math.min(0.8, contrast));
     return {
       countExp: contrast,
       // Floor: every species in the dataset must be visible, even

--- a/homeassistant/www/config.js
+++ b/homeassistant/www/config.js
@@ -65,10 +65,12 @@ window.AV_CONFIG = {
   collageFill: 0.5,
 
   // Size contrast: how much bigger your most-heard birds are drawn than
-  // the rest (0.2 - 0.8). Lower keeps every bird closer to the same size;
+  // the rest (0 - 0.8). Lower keeps every bird closer to the same size;
   // higher lets the loudest few dominate. 0.5 (default) makes the top
   // birds a few times bigger than a quiet one - noticeable but not
-  // overpowering. (The old fixed value was 0.65, which felt top-heavy.)
+  // overpowering. At 0 every bird is drawn essentially the same size,
+  // regardless of how common it is. (The old fixed value was 0.65, which
+  // felt top-heavy.)
   sizeContrast: 0.5,
 
   // Collage shape: how the flock is arranged on the plate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "habird-dashboard",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "private": true,
   "description": "Bird Card - a live bird collage card for Home Assistant, fed by BirdNET-Go",
   "license": "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
## What

Lets the **size contrast** between common and rare birds go all the way down to **0**, so the whole flock can be drawn essentially the same size regardless of how often each bird is heard.

Previously `sizeContrast` was clamped to `0.2`–`0.8`. At `0` the count exponent becomes `0`, so every bird's score is `n^0 = 1` and all tiles get equal area. The default (`0.5`) is unchanged.

## Changes

- **Renderer** (`homeassistant/www/apt.js`): clamp floor `0.2` → `0`.
- **Card editor** (`homeassistant/card/build.js`): slider `min` `0.2` → `0`, updated help text.
- **config.js**: doc range `0–0.8`, note that 0 = uniform.
- **Bird Frame add-on** (`config.yaml` schema `float(0,0.8)`, `options.py` comment).
- Rebuilt `dist/habird-card.js` and synced `addons/birdframe/www/`.
- Bumped to **1.2.3** (build.js, addon config, package.json) + CHANGELOG entry.

## Test

`npm test` — 13/13 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)