### PR TITLE
Fix detail-modal first-heard timestamp parsing; make the pose toggle flip on click

### DIFF
--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -3421,10 +3421,14 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
   var modalRecBtn = null;
   var __modalSci = null;   // species currently shown in the detail modal
   function fmtRecTime(d, t) {
-    // d="2026-05-15", t="20:25:29"
+    // Either a date "2026-05-15" with a separate time t="20:25:29", or a
+    // single full timestamp that already carries its own time - e.g.
+    // "2026-07-09T04:47:17+02:00" (ISO, offset) or "2026-07-09 04:47:17".
+    // When d already holds a time, parse the whole string; otherwise the
+    // ISO 'T'/offset would be mangled by appending 'T'+t.
     if (!d) return '-';
-    var date = new Date((d || '') + 'T' + (t || '00:00:00'));
-    if (isNaN(date.getTime())) return d + ' ' + (t || '');
+    var date = /[T ]\d\d:/.test(d) ? new Date(d) : new Date((d || '') + 'T' + (t || '00:00:00'));
+    if (isNaN(date.getTime())) return t ? (d + ' ' + t) : d;
     var now = Date.now();
     var ago = Math.floor((now - date.getTime()) / 1000);
     if (ago < 60) return ago + 's ago';
@@ -3820,7 +3824,7 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
       __root.getElementById('modalAllTime').textContent = fmtN(+s.total || 0);
       var winRow = ((DATA.recent && DATA.recent.species) || []).filter(function (x) { return x.sci === sci; })[0];
       __root.getElementById('modalWindow').textContent = fmtN(winRow ? +winRow.n : 0);
-      __root.getElementById('modalFirstSeen').textContent = s.first_seen ? fmtRecTime(s.first_seen.split(' ')[0], s.first_seen.split(' ')[1]) : '-';
+      __root.getElementById('modalFirstSeen').textContent = s.first_seen ? fmtRecTime(s.first_seen) : '-';
       var rar = rarityLabel(+s.total || 0, s.first_seen);
       var rarEl = __root.getElementById('modalRarity');
       rarEl.textContent = rar;

--- a/dist/habird-card.js
+++ b/dist/habird-card.js
@@ -3987,10 +3987,20 @@ function runHABirdApp(__root, __shell, __cardConfig, __imgBase) {
   // (default) and in-flight alt pose. A short opacity transition makes
   // the swap feel intentional rather than a hard cut.
   __root.getElementById('modalPoseToggle').addEventListener('click', function (ev) {
+    var toggle = __root.getElementById('modalPoseToggle');
     var btn = ev.target.closest && ev.target.closest('button');
     if (!btn || btn.getAttribute('data-unavailable') === 'true') return;
+    // Doubles as a toggle: this control's two buttons tile its whole width,
+    // so there's no open space for wireToggleAdvance to catch. Clicking the
+    // already-active pose therefore advances to the other available one.
+    if (btn.getAttribute('aria-current') === 'true') {
+      var avail = [].slice.call(toggle.querySelectorAll('button')).filter(function (b) {
+        return !b.disabled && b.getAttribute('data-unavailable') !== 'true';
+      });
+      if (avail.length < 2) return;   // only one pose exists - nothing to flip to
+      btn = avail[(avail.indexOf(btn) + 1) % avail.length];
+    }
     var pose = +btn.dataset.pose;
-    var toggle = __root.getElementById('modalPoseToggle');
     [].slice.call(toggle.querySelectorAll('button')).forEach(function (b) {
       b.setAttribute('aria-current', b === btn ? 'true' : 'false');
     });

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -3945,10 +3945,20 @@
   // (default) and in-flight alt pose. A short opacity transition makes
   // the swap feel intentional rather than a hard cut.
   document.getElementById('modalPoseToggle').addEventListener('click', function (ev) {
+    var toggle = document.getElementById('modalPoseToggle');
     var btn = ev.target.closest && ev.target.closest('button');
     if (!btn || btn.getAttribute('data-unavailable') === 'true') return;
+    // Doubles as a toggle: this control's two buttons tile its whole width,
+    // so there's no open space for wireToggleAdvance to catch. Clicking the
+    // already-active pose therefore advances to the other available one.
+    if (btn.getAttribute('aria-current') === 'true') {
+      var avail = [].slice.call(toggle.querySelectorAll('button')).filter(function (b) {
+        return !b.disabled && b.getAttribute('data-unavailable') !== 'true';
+      });
+      if (avail.length < 2) return;   // only one pose exists - nothing to flip to
+      btn = avail[(avail.indexOf(btn) + 1) % avail.length];
+    }
     var pose = +btn.dataset.pose;
-    var toggle = document.getElementById('modalPoseToggle');
     [].slice.call(toggle.querySelectorAll('button')).forEach(function (b) {
       b.setAttribute('aria-current', b === btn ? 'true' : 'false');
     });

--- a/homeassistant/www/apt.js
+++ b/homeassistant/www/apt.js
@@ -3379,10 +3379,14 @@
   var modalRecBtn = null;
   var __modalSci = null;   // species currently shown in the detail modal
   function fmtRecTime(d, t) {
-    // d="2026-05-15", t="20:25:29"
+    // Either a date "2026-05-15" with a separate time t="20:25:29", or a
+    // single full timestamp that already carries its own time - e.g.
+    // "2026-07-09T04:47:17+02:00" (ISO, offset) or "2026-07-09 04:47:17".
+    // When d already holds a time, parse the whole string; otherwise the
+    // ISO 'T'/offset would be mangled by appending 'T'+t.
     if (!d) return '-';
-    var date = new Date((d || '') + 'T' + (t || '00:00:00'));
-    if (isNaN(date.getTime())) return d + ' ' + (t || '');
+    var date = /[T ]\d\d:/.test(d) ? new Date(d) : new Date((d || '') + 'T' + (t || '00:00:00'));
+    if (isNaN(date.getTime())) return t ? (d + ' ' + t) : d;
     var now = Date.now();
     var ago = Math.floor((now - date.getTime()) / 1000);
     if (ago < 60) return ago + 's ago';
@@ -3778,7 +3782,7 @@
       document.getElementById('modalAllTime').textContent = fmtN(+s.total || 0);
       var winRow = ((DATA.recent && DATA.recent.species) || []).filter(function (x) { return x.sci === sci; })[0];
       document.getElementById('modalWindow').textContent = fmtN(winRow ? +winRow.n : 0);
-      document.getElementById('modalFirstSeen').textContent = s.first_seen ? fmtRecTime(s.first_seen.split(' ')[0], s.first_seen.split(' ')[1]) : '-';
+      document.getElementById('modalFirstSeen').textContent = s.first_seen ? fmtRecTime(s.first_seen) : '-';
       var rar = rarityLabel(+s.total || 0, s.first_seen);
       var rarEl = document.getElementById('modalRarity');
       rarEl.textContent = rar;


### PR DESCRIPTION
> Note that this PR is part 1 of a total of 2 PRs. The next one (#63) will contain support for i18n (with Danish language), but it depends on this branch being merged first, so I leave it as draft until this merges.

## 1. "First heard" fell back to a raw timestamp string

### Problem

BirdNET-Go reports `first_seen` as a full timestamp — either `2026-07-09T04:47:17+02:00` (ISO with offset) or `2026-07-09 04:47:17`. The modal split it on a space and passed the halves to `fmtRecTime(d, t)`:

```js
fmtRecTime(s.first_seen.split(' ')[0], s.first_seen.split(' ')[1])
```

For the ISO form there is no space, so `d` became the entire string and `t` was `undefined`. `fmtRecTime` then built `new Date(d + 'T' + '00:00:00')` — i.e. `"2026-07-09T04:47:17+02:00T00:00:00"` — which is an invalid `Date`, so the field bailed to the `isNaN` branch and rendered the raw string instead of a relative age.

### Fix

Detect a time already present in the first argument and parse the whole string; otherwise keep the existing `d` + `t` join, so the other callers are unaffected. The call site simplifies to `fmtRecTime(s.first_seen)`. Relative-age output is unchanged.

## 2. The pose toggle ignored clicks on the active side

### Problem

`#modalPoseToggle`'s two buttons tile the control's entire width, so there is no open space for `wireToggleAdvance` to catch. Clicking the already-selected pose did nothing, where a two-state control is expected to flip.

### Fix

When the clicked button is already `aria-current="true"`, advance to the next available pose. Guarded so a species with only one usable pose stays a no-op.

## Test plan

- [x] `npm test` — 13/13 suites pass
- [x] `dist/habird-card.js` rebuilt from source; a subsequent `npm run build` produces no further diff

Neither fix ships a dedicated regression test — the existing suites cover the surrounding code but would not catch either bug specifically. Happy to add targeted tests if you'd like them before merging.

## Not included

No version bump or CHANGELOG entry, since those look like part of your release step rather than the fix itself. Say the word if you'd prefer them in this PR.
